### PR TITLE
Use explicit Rust setup inputs

### DIFF
--- a/rust/.github/workflows/build.yaml.jinja
+++ b/rust/.github/workflows/build.yaml.jinja
@@ -41,7 +41,12 @@ jobs:
       with:
         version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
-    - uses: actions-ext/rust/setup@c9cdbe5cc8a2485bf2eb22644302559c741ca763
+    - uses: actions-ext/rust/setup@7d919b14e08dc1155a267dffbcc58260bdfdd63b
+      with:
+        targets: {% raw %}${{ runner.os == 'macOS' && 'aarch64-apple-darwin' || '' }}{% endraw %}
+        tools: |
+          cargo-nextest@0.9.140
+          cargo-llvm-cov@0.8.7
 
     - name: Install dependencies
       run: make develop

--- a/rust/rust/Makefile.jinja
+++ b/rust/rust/Makefile.jinja
@@ -1,10 +1,12 @@
+CARGO_NEXTEST_VERSION ?= 0.9.140
+CARGO_LLVM_COV_VERSION ?= 0.8.7
 
 .PHONY: requirements develop build
 requirements:  ## install required dev dependencies
 	rustup component add rustfmt
 	rustup component add clippy
-	cargo install --locked --force cargo-nextest
-	cargo install --force cargo-llvm-cov
+	command -v cargo-nextest >/dev/null 2>&1 || cargo install --locked cargo-nextest --version =$(CARGO_NEXTEST_VERSION)
+	command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install --locked cargo-llvm-cov --version =$(CARGO_LLVM_COV_VERSION)
 
 develop: requirements  ## install required dev dependencies
 

--- a/rustjswasm/.github/workflows/build.yaml.jinja
+++ b/rustjswasm/.github/workflows/build.yaml.jinja
@@ -42,7 +42,13 @@ jobs:
       with:
         version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
-    - uses: actions-ext/rust/setup@c9cdbe5cc8a2485bf2eb22644302559c741ca763
+    - uses: actions-ext/rust/setup@7d919b14e08dc1155a267dffbcc58260bdfdd63b
+      with:
+        targets: {% raw %}${{ runner.os == 'macOS' && 'aarch64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}{% endraw %}
+        tools: |
+          cargo-nextest@0.9.140
+          cargo-llvm-cov@0.8.7
+          wasm-bindgen-cli@0.2.126
 
     - uses: actions-ext/node/setup@3478453a763ed3c8c6eba05a092ab81a265c5492
       with:

--- a/rustjswasm/rust/Makefile.jinja
+++ b/rustjswasm/rust/Makefile.jinja
@@ -1,11 +1,14 @@
+CARGO_NEXTEST_VERSION ?= 0.9.140
+CARGO_LLVM_COV_VERSION ?= 0.8.7
+WASM_BINDGEN_CLI_VERSION ?= 0.2.126
 
 .PHONY: requirements develop build
 requirements:  ## install required dev dependencies
 	rustup component add rustfmt
 	rustup component add clippy
-	cargo install --force --locked cargo-nextest
-	cargo install --force --locked cargo-llvm-cov
-	cargo install --force --locked wasm-bindgen-cli --version 0.2.126
+	command -v cargo-nextest >/dev/null 2>&1 || cargo install --locked cargo-nextest --version =$(CARGO_NEXTEST_VERSION)
+	command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install --locked cargo-llvm-cov --version =$(CARGO_LLVM_COV_VERSION)
+	command -v wasm-bindgen >/dev/null 2>&1 || cargo install --locked wasm-bindgen-cli --version =$(WASM_BINDGEN_CLI_VERSION)
 	rustup target add wasm32-unknown-unknown
 
 develop: requirements  ## install required dev dependencies


### PR DESCRIPTION
Pins actions-ext/rust/setup at functional commit 7d919b14e08dc1155a267dffbcc58260bdfdd63b. Plain Rust requests only the macOS ARM target when needed; Rust/WASM requests wasm32 explicitly and adds macOS ARM conditionally. Both templates install exact Cargo tool versions through the action, while generated Makefiles skip tools already present instead of forcing recompilation.

Rendered and actionlint-validated both variants for Python 3.10 through 3.13. Generated Rust subprojects and requirement targets also pass locally.