### PR TITLE
Free runner disk space before building wheels

### DIFF
--- a/rust/.github/workflows/build.yaml.jinja
+++ b/rust/.github/workflows/build.yaml.jinja
@@ -83,6 +83,13 @@ jobs:
         platforms: all
       if: runner.os == 'Linux' && runner.arch == 'X64'
 
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/share/swift
+        df -h /
+      shell: bash
+      if: matrix.os == 'ubuntu-latest'
+
     - name: Make dist (Linux)
       run: |
         rm -rf dist

--- a/rustjswasm/.github/workflows/build.yaml.jinja
+++ b/rustjswasm/.github/workflows/build.yaml.jinja
@@ -89,6 +89,13 @@ jobs:
         platforms: all
       if: runner.os == 'Linux' && runner.arch == 'X64'
 
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/share/swift
+        df -h /
+      shell: bash
+      if: matrix.os == 'ubuntu-latest'
+
     - name: Make dist (Linux)
       run: |
         rm -rf dist


### PR DESCRIPTION
The cibuildwheel container shares the runner's 72G root filesystem with the
host, and the Linux dist step exhausts it before the wheel test install runs:

    ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device
    cibuildwheel: Command ['pip', 'install', '...whl[develop]'] failed with code 1

Measured on a failing job, at the point the container starts testing:

| | Free on `/` |
| --- | --- |
| Host, start of `Make dist` | 7.2G of 72G |
| Container, at test time | 168M, 100% full |

The container's `overlay` and the host's `/dev/root` are the same filesystem.
What consumes the remaining headroom:

- `/project/target` — 4.2G, the bind-mounted workspace Rust target dir, already
  populated by the earlier `make build` / `make coverage` steps
- `/root/.rustup` 756M + `/root/.cargo` 129M, from `before-all` installing the
  `aarch64` and `x86_64` toolchains inside the container
- `/var/lib/docker` 4.0K to 2.1G just pulling the manylinux image

Dropping the Android/dotnet/GHC/Swift toolchains, none of which these builds
use, takes free space from 7.2G to 30G. `/opt/hostedtoolcache` is deliberately
left alone since setup-python's interpreter lives there.

Verified on 1kbgz/crowdsource-admin, which was failing reproducibly: free space
went 7.2G to 30G and `Testing wheel...` now completes instead of dying.

Applied to the `rust` and `rustjswasm` variants only. `cpp` and `cppjswasm`
have the same dist step shape, but the three consumers above are Rust-specific,
so I did not want to ship an unvalidated change to variants that may not have
the problem.

Worth noting separately: `test-extras = "develop"` installs the entire dev
toolchain (uv, ty, ruff, cibuildwheel, twine, bump-my-version, ...) into the
container to run the test suite. That is what pushes disk over the edge, so
narrowing it to a test-only extra would address the cause rather than buy
headroom.