### PR TITLE
Update vcpkg cache action

### DIFF
--- a/cpp/.github/workflows/build.yaml.jinja
+++ b/cpp/.github/workflows/build.yaml.jinja
@@ -62,7 +62,7 @@ jobs:
     - uses: actions-ext/cpp/setup@51c484ef64088c62434226039d0e3359f5fc8df6
 
     {% if add_vcpkg -%}
-    - uses: actions-ext/cpp/setup-vcpkg-cache@6ded4958b7e13d73428138a01d53c33cb941121d
+    - uses: actions-ext/cpp/setup-vcpkg-cache@c2b1e90366b3a1c628a1df0748135f5e345ab26f
 
     {% endif -%}
     - name: Install dependencies

--- a/cppjswasm/.github/workflows/build.yaml.jinja
+++ b/cppjswasm/.github/workflows/build.yaml.jinja
@@ -50,7 +50,7 @@ jobs:
     - uses: actions-ext/cpp/setup@51c484ef64088c62434226039d0e3359f5fc8df6
 
     {% if add_vcpkg -%}
-    - uses: actions-ext/cpp/setup-vcpkg-cache@6ded4958b7e13d73428138a01d53c33cb941121d
+    - uses: actions-ext/cpp/setup-vcpkg-cache@c2b1e90366b3a1c628a1df0748135f5e345ab26f
 
     {% endif -%}
     - uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16


### PR DESCRIPTION
Pins the C++ and C++/JS/WASM templates to actions-ext/cpp@c2b1e90366b3a1c628a1df0748135f5e345ab26f. This revision restores the nearest compatible cache and saves rebuilt packages under a fresh key for each workflow run and attempt, preventing stale vcpkg ABI caches after compiler updates.

Generated both affected variants and parsed the resulting workflows as YAML.