### PR TITLE
Use consolidated Copier update action

### DIFF
--- a/cpp/.github/workflows/copier.yaml
+++ b/cpp/.github/workflows/copier.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update from Copier
-        uses: actions-ext/copier-update@378500315a83b5985e175139a55f1fa5ea6dde09
+        uses: actions-ext/copier/update@2061209faa6b75ffd4fcecc0b0983772767997f4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/cppjswasm/.github/workflows/copier.yaml
+++ b/cppjswasm/.github/workflows/copier.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update from Copier
-        uses: actions-ext/copier-update@378500315a83b5985e175139a55f1fa5ea6dde09
+        uses: actions-ext/copier/update@2061209faa6b75ffd4fcecc0b0983772767997f4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/js/.github/workflows/copier.yaml
+++ b/js/.github/workflows/copier.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update from Copier
-        uses: actions-ext/copier-update@378500315a83b5985e175139a55f1fa5ea6dde09
+        uses: actions-ext/copier/update@2061209faa6b75ffd4fcecc0b0983772767997f4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/jupyter/.github/workflows/copier.yaml
+++ b/jupyter/.github/workflows/copier.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update from Copier
-        uses: actions-ext/copier-update@378500315a83b5985e175139a55f1fa5ea6dde09
+        uses: actions-ext/copier/update@2061209faa6b75ffd4fcecc0b0983772767997f4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/python/.github/workflows/copier.yaml
+++ b/python/.github/workflows/copier.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update from Copier
-        uses: actions-ext/copier-update@378500315a83b5985e175139a55f1fa5ea6dde09
+        uses: actions-ext/copier/update@2061209faa6b75ffd4fcecc0b0983772767997f4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/rust/.github/workflows/copier.yaml
+++ b/rust/.github/workflows/copier.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update from Copier
-        uses: actions-ext/copier-update@378500315a83b5985e175139a55f1fa5ea6dde09
+        uses: actions-ext/copier/update@2061209faa6b75ffd4fcecc0b0983772767997f4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/rustjswasm/.github/workflows/copier.yaml
+++ b/rustjswasm/.github/workflows/copier.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update from Copier
-        uses: actions-ext/copier-update@378500315a83b5985e175139a55f1fa5ea6dde09
+        uses: actions-ext/copier/update@2061209faa6b75ffd4fcecc0b0983772767997f4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
Moves all generated template workflows from the standalone actions-ext/copier-update repository to the consolidated actions-ext/copier/update action, pinned to commit 2061209faa6b75ffd4fcecc0b0983772767997f4.

Rendered all seven variants; every generated workflow passes yamllint with GitHub-compatible rules and actionlint.