### PR TITLE
Refresh template dependencies

### DIFF
--- a/cpp/.github/workflows/build.yaml.jinja
+++ b/cpp/.github/workflows/build.yaml.jinja
@@ -62,7 +62,7 @@ jobs:
           version: {% raw %}${{ matrix.python.version }}{% endraw %}
 
       - name: Setup C++
-        uses: actions-ext/cpp/setup@51c484ef64088c62434226039d0e3359f5fc8df6
+        uses: actions-ext/cpp/setup@c2b1e90366b3a1c628a1df0748135f5e345ab26f
 
       {% if add_vcpkg -%}
       - name: Setup vcpkg cache

--- a/cppjswasm/.github/workflows/build.yaml.jinja
+++ b/cppjswasm/.github/workflows/build.yaml.jinja
@@ -51,7 +51,7 @@ jobs:
           version: {% raw %}${{ matrix.node-version }}{% endraw %}
 
       - name: Setup C++
-        uses: actions-ext/cpp/setup@51c484ef64088c62434226039d0e3359f5fc8df6
+        uses: actions-ext/cpp/setup@c2b1e90366b3a1c628a1df0748135f5e345ab26f
 
       {% if add_vcpkg -%}
       - name: Setup vcpkg cache

--- a/cppjswasm/js/package.json.jinja
+++ b/cppjswasm/js/package.json.jinja
@@ -48,14 +48,14 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.62.0",
     "cpy": "^13.2.2",
-    "esbuild": "^0.28.0",
-    "lightningcss": "^1.29.3",
+    "esbuild": "^0.28.1",
+    "lightningcss": "^1.33.0",
     "http-server": "^14.1.1",
     "nodemon": "^3.1.10",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.8.1",
-    "typescript": "^6.0.2"
+    "prettier": "^3.9.6",
+    "typescript": "^7.0.2"
   }
 }

--- a/js/js/package.json.jinja
+++ b/js/js/package.json.jinja
@@ -41,14 +41,14 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.62.0",
     "cpy": "^13.2.2",
-    "esbuild": "^0.28.0",
-    "lightningcss": "^1.29.3",
+    "esbuild": "^0.28.1",
+    "lightningcss": "^1.33.0",
     "http-server": "^14.1.1",
     "nodemon": "^3.1.10",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.8.1",
-    "typescript": "^6.0.2"
+    "prettier": "^3.9.6",
+    "typescript": "^7.0.2"
   }
 }

--- a/jupyter/js/package.json.jinja
+++ b/jupyter/js/package.json.jinja
@@ -46,15 +46,15 @@
     "@jupyterlab/application": "^4.5.7",
     "@jupyterlab/apputils": "^4.6.7",
     "@jupyterlab/notebook": "^4.5.7",
-    "@jupyterlab/services": "^7.5.7",
+    "@jupyterlab/services": "^7.5.10",
     "@lumino/disposable": "^2.1.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",
     "@babel/core": "^7.29.0",
     "@babel/eslint-parser": "^7.28.6",
-    "@babel/preset-env": "^7.29.2",
-    "@jupyterlab/builder": "^4.5.6",
+    "@babel/preset-env": "^7.29.3",
+    "@jupyterlab/builder": "^4.5.10",
     "babel-jest": "^30.4.1",
     "cpy-cli": "^6.0.0",
     "eslint": "^8.57.1",
@@ -62,7 +62,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^29.12.1",
+    "eslint-plugin-jest": "^29.16.0",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-prettier": "^5.5.4",
     "isomorphic-fetch": "^3.0.0",
@@ -71,7 +71,7 @@
     "jest-junit": "^17.0.0",
     "jest-transform-css": "^6.0.3",
     "mkdirp": "^3.0.1",
-    "prettier": "^3.8.1",
+    "prettier": "^3.9.6",
     "rimraf": "^6.1.3"
   }
 }

--- a/rust/.github/workflows/build.yaml.jinja
+++ b/rust/.github/workflows/build.yaml.jinja
@@ -44,7 +44,7 @@ jobs:
           version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@c9cdbe5cc8a2485bf2eb22644302559c741ca763
+        uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
 
       - name: Install dependencies
         run: make develop

--- a/rustjswasm/.github/workflows/build.yaml.jinja
+++ b/rustjswasm/.github/workflows/build.yaml.jinja
@@ -45,7 +45,7 @@ jobs:
           version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@c9cdbe5cc8a2485bf2eb22644302559c741ca763
+        uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
 
       - name: Setup Node.js
         uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f

--- a/rustjswasm/js/package.json.jinja
+++ b/rustjswasm/js/package.json.jinja
@@ -51,14 +51,14 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.62.0",
     "cpy": "^13.2.2",
-    "esbuild": "^0.28.0",
-    "lightningcss": "^1.29.3",
+    "esbuild": "^0.28.1",
+    "lightningcss": "^1.33.0",
     "http-server": "^14.1.1",
-    "nodemon": "^3.1.10",
+    "nodemon": "^3.1.14",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.8.1",
-    "typescript": "^6.0.2"
+    "prettier": "^3.9.6",
+    "typescript": "^7.0.2"
   }
 }


### PR DESCRIPTION
Propagates passing dependency updates from the generated example repositories back into their source templates. Refreshes shared JavaScript tooling, JupyterLab packages, and the C++/Rust setup action pins across affected variants.

Carries forward previously merged instance upgrades such as esbuild 0.28.1, Babel preset-env 7.29.3, and nodemon 3.1.14 so new generated projects do not start behind current examples.

Does not take `eslint-plugin-json` 5: its instance PR fails because that release is incompatible with the current ESLint 8 legacy configuration.

Affected variants generate successfully. Combined JS lint/build, Jupyter lint/tests, JS/WASM linting, and generated workflow YAML lint pass.