### PR TITLE
Install Yardang documentation extras

### DIFF
--- a/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,14 +39,14 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           make develop
           uv pip install .
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/python/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,14 +39,14 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           make develop
           uv pip install .
-          uv pip install yardang
+          uv pip install "yardang[llms,themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation


### PR DESCRIPTION
Install Yardang with the `llms` and `themes` extras in generated documentation workflows so LLM output and bundled theme support are available for wheel-triggered and manual builds.