### PR TITLE
Simplify GitHub workflow expressions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,5 +95,5 @@ jobs:
 
       - name: Generate and test template
         run: |
-          make gen-${{matrix.template}}
-          make test-${{matrix.template}}
+          make gen-${{ matrix.template }}
+          make test-${{ matrix.template }}

--- a/cpp/.github/workflows/build.yaml.jinja
+++ b/cpp/.github/workflows/build.yaml.jinja
@@ -147,5 +147,5 @@ jobs:
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}dist-${{matrix.os}}-${{matrix.python.version}}{% endraw %}
+          name: {% raw %}dist-${{ matrix.os }}-${{ matrix.python.version }}{% endraw %}
           path: dist

--- a/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: {% raw %}${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}{% endraw %}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/cppjswasm/.github/workflows/build.yaml.jinja
+++ b/cppjswasm/.github/workflows/build.yaml.jinja
@@ -30,9 +30,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["{{ python_version_primary }}"]
-        cibuildwheel: ["cp{{python_version_primary.replace('.', '')}}"]
-        node-version: [22.x]
 
     steps:
       - name: Checkout
@@ -43,12 +40,12 @@ jobs:
       - name: Setup Python
         uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
-          version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          version: "{{ python_version_primary }}"
 
       - name: Setup Node.js
         uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
         with:
-          version: {% raw %}${{ matrix.node-version }}{% endraw %}
+          version: 22.x
 
       - name: Setup C++
         uses: actions-ext/cpp/setup@c2b1e90366b3a1c628a1df0748135f5e345ab26f
@@ -78,7 +75,7 @@ jobs:
       - name: Upload test results (Python)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}test-results-${{ matrix.os }}-${{ matrix.python-version }}{% endraw %}
+          name: {% raw %}test-results-${{ matrix.os }}{% endraw %}
           path: junit.xml
         if: matrix.os == 'ubuntu-latest'
 
@@ -103,7 +100,7 @@ jobs:
           make dist-py-wheel
           make dist-check
         env:
-          CIBW_BUILD: {% raw %}"${{ matrix.cibuildwheel }}-manylinux*"{% endraw %}
+          CIBW_BUILD: "cp{{ python_version_primary.replace('.', '') }}-manylinux*"
           CIBW_BUILD_VERBOSITY: 3
         if: matrix.os == 'ubuntu-latest'
 
@@ -112,7 +109,7 @@ jobs:
           rm -rf dist
           make dist-py-wheel
         env:
-          CIBW_BUILD: {% raw %}"${{ matrix.cibuildwheel }}-macos*"{% endraw %}
+          CIBW_BUILD: "cp{{ python_version_primary.replace('.', '') }}-macos*"
           CIBW_BUILD_VERBOSITY: 3
         if: matrix.os == 'macos-latest'
 
@@ -121,7 +118,7 @@ jobs:
           if (Test-Path dist) { Remove-Item dist -Recurse -Force }
           make dist-py-wheel
         env:
-          CIBW_BUILD: {% raw %}"${{ matrix.cibuildwheel }}-win_amd64"{% endraw %}
+          CIBW_BUILD: "cp{{ python_version_primary.replace('.', '') }}-win_amd64"
         if: matrix.os == 'windows-latest'
 
       - name: Test wheel
@@ -139,5 +136,5 @@ jobs:
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}dist-${{matrix.os}}-${{matrix.python-version}}{% endraw %}
+          name: {% raw %}dist-${{ matrix.os }}{% endraw %}
           path: dist

--- a/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: {% raw %}${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}{% endraw %}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -27,7 +27,7 @@ jobs:
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
-          pattern: dist-ubuntu-latest-{{python_version_primary}}
+          pattern: dist-ubuntu-latest
           merge-multiple: true
           path: dist
           run-id: {% raw %}${{ github.event.workflow_run.id }}{% endraw %}

--- a/js/.github/workflows/build.yaml.jinja
+++ b/js/.github/workflows/build.yaml.jinja
@@ -25,13 +25,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["{{ python_version_primary }}"]
-        node-version: [22.x]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -42,43 +36,39 @@ jobs:
       - name: Setup Python
         uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
-          version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          version: "{{ python_version_primary }}"
 
       - name: Setup Node.js
         uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
         with:
-          version: {% raw %}${{ matrix.node-version }}{% endraw %}
+          version: 22.x
 
       - name: Install dependencies
         run: make develop
 
       - name: Lint
         run: make lint
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Checks
         run: make checks
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Build
         run: make build
 
       - name: Test
         run: make coverage
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.node-version }}{% endraw %}
+          name: test-results
           path: '**/junit.xml'
-        if: {% raw %}${{ always() }}{% endraw %}
+        if: always()
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
         with:
           files: '**/junit.xml'
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
@@ -87,23 +77,19 @@ jobs:
 
       - name: Build distributions
         run: make dist
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Test wheel
         uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Test source distribution
         uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}dist-${{matrix.os}}{% endraw %}
+          name: dist
           path: dist
-        if: matrix.os == 'ubuntu-latest'

--- a/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: {% raw %}${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}{% endraw %}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -27,7 +27,7 @@ jobs:
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
-          pattern: dist-ubuntu-latest*
+          pattern: dist
           merge-multiple: true
           path: dist
           run-id: {% raw %}${{ github.event.workflow_run.id }}{% endraw %}

--- a/jupyter/.github/workflows/build.yaml.jinja
+++ b/jupyter/.github/workflows/build.yaml.jinja
@@ -25,13 +25,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["{{ python_version_primary }}"]
-        node-version: [22.x]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -42,43 +36,39 @@ jobs:
       - name: Setup Python
         uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
-          version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          version: "{{ python_version_primary }}"
 
       - name: Setup Node.js
         uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
         with:
-          version: {% raw %}${{ matrix.node-version }}{% endraw %}
+          version: 22.x
 
       - name: Install dependencies
         run: make develop
 
       - name: Lint
         run: make lint
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Checks
         run: make checks
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Build
         run: make build
 
       - name: Test
         run: make coverage
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Upload test results (Python)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.node-version }}{% endraw %}
+          name: test-results
           path: '**/junit.xml'
-        if: {% raw %}${{ always() }}{% endraw %}
+        if: always()
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
         with:
           files: '**/junit.xml'
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
@@ -87,23 +77,19 @@ jobs:
 
       - name: Build distributions
         run: make dist
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Test wheel
         uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Test source distribution
         uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}dist-${{matrix.os}}{% endraw %}
+          name: dist
           path: dist
-        if: matrix.os == 'ubuntu-latest'

--- a/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: {% raw %}${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}{% endraw %}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -27,7 +27,7 @@ jobs:
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
-          pattern: dist-ubuntu-latest*
+          pattern: dist
           merge-multiple: true
           path: dist
           run-id: {% raw %}${{ github.event.workflow_run.id }}{% endraw %}

--- a/python/.github/workflows/build.yaml.jinja
+++ b/python/.github/workflows/build.yaml.jinja
@@ -25,12 +25,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["{{ python_version_primary }}"]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -41,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
-          version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          version: "{{ python_version_primary }}"
 
       - name: Install dependencies
         run: make develop
@@ -61,9 +56,9 @@ jobs:
       - name: Upload test results (Python)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}test-results-${{ matrix.os }}-${{ matrix.python-version }}{% endraw %}
+          name: test-results
           path: junit.xml
-        if: {% raw %}${{ always() }}{% endraw %}
+        if: always()
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
@@ -91,5 +86,5 @@ jobs:
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}dist-${{matrix.os}}{% endraw %}
+          name: dist
           path: dist

--- a/python/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: {% raw %}${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}{% endraw %}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -27,7 +27,7 @@ jobs:
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
-          pattern: dist-ubuntu-latest*
+          pattern: dist
           merge-multiple: true
           path: dist
           run-id: {% raw %}${{ github.event.workflow_run.id }}{% endraw %}

--- a/rust/.github/workflows/build.yaml.jinja
+++ b/rust/.github/workflows/build.yaml.jinja
@@ -30,7 +30,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["{{ python_version_primary }}"]
 
     steps:
       - name: Checkout
@@ -41,7 +40,7 @@ jobs:
       - name: Setup Python
         uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
-          version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          version: "{{ python_version_primary }}"
 
       - name: Setup Rust
         uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
@@ -65,9 +64,9 @@ jobs:
       - name: Upload test results (Python)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}test-results-${{ matrix.os }}-${{ matrix.python-version }}{% endraw %}
+          name: {% raw %}test-results-${{ matrix.os }}{% endraw %}
           path: '**/junit.xml'
-        if: {% raw %}${{ always() }}{% endraw %}
+        if: always()
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
@@ -128,5 +127,5 @@ jobs:
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}dist-${{matrix.os}}{% endraw %}
+          name: {% raw %}dist-${{ matrix.os }}{% endraw %}
           path: dist

--- a/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: {% raw %}${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}{% endraw %}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/rustjswasm/.github/workflows/build.yaml.jinja
+++ b/rustjswasm/.github/workflows/build.yaml.jinja
@@ -30,8 +30,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["{{ python_version_primary }}"]
-        node-version: [22.x]
 
     steps:
       - name: Checkout
@@ -42,7 +40,7 @@ jobs:
       - name: Setup Python
         uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
-          version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          version: "{{ python_version_primary }}"
 
       - name: Setup Rust
         uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
@@ -50,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
         with:
-          version: {% raw %}${{ matrix.node-version }}{% endraw %}
+          version: 22.x
 
       - name: Install dependencies
         run: make develop
@@ -72,7 +70,7 @@ jobs:
       - name: Upload test results (Python)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}test-results-${{ matrix.os }}-${{ matrix.python-version }}{% endraw %}
+          name: {% raw %}test-results-${{ matrix.os }}{% endraw %}
           path: '**/junit.xml'
         if: matrix.os == 'ubuntu-latest'
 
@@ -135,5 +133,5 @@ jobs:
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: {% raw %}dist-${{matrix.os}}{% endraw %}
+          name: {% raw %}dist-${{ matrix.os }}{% endraw %}
           path: dist

--- a/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: {% raw %}${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}{% endraw %}
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1


### PR DESCRIPTION
Remove redundant expression delimiters, singleton matrix axes, and Ubuntu checks from generated workflows. Keep runtime interpolation and OS conditions only where jobs vary across runners. Rendered workflows pass structural YAML validation and actionlint.