### PR TITLE
Move app installation note to base README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ pip install copier
 copier copy https://github.com/python-project-templates/base.git path/to/new/project
 ```
 
+> [!NOTE]
+> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) on repositories generated from this template to receive weekly template update pull requests.

--- a/cpp/README.md.jinja
+++ b/cpp/README.md.jinja
@@ -11,5 +11,3 @@
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
->
-> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) to receive weekly template update pull requests.

--- a/cppjswasm/README.md.jinja
+++ b/cppjswasm/README.md.jinja
@@ -11,5 +11,3 @@
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
->
-> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) to receive weekly template update pull requests.

--- a/js/README.md.jinja
+++ b/js/README.md.jinja
@@ -11,5 +11,3 @@
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
->
-> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) to receive weekly template update pull requests.

--- a/jupyter/README.md.jinja
+++ b/jupyter/README.md.jinja
@@ -12,5 +12,3 @@
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
->
-> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) to receive weekly template update pull requests.

--- a/python/README.md.jinja
+++ b/python/README.md.jinja
@@ -11,5 +11,3 @@
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
->
-> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) to receive weekly template update pull requests.

--- a/rust/README.md.jinja
+++ b/rust/README.md.jinja
@@ -11,5 +11,3 @@
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
->
-> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) to receive weekly template update pull requests.

--- a/rustjswasm/README.md.jinja
+++ b/rustjswasm/README.md.jinja
@@ -11,5 +11,3 @@
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
->
-> Install the [Python Templates Copier Update GitHub App](https://github.com/apps/python-templates-copier-update) to receive weekly template update pull requests.


### PR DESCRIPTION
Keep Copier Update GitHub App installation guidance in the template repository README instead of copying it into every generated project README.