### PR TITLE
Remove Yardang llms extra from docs workflows

### DIFF
--- a/python/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/python/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,14 +39,14 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           make develop
           uv pip install .
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/python/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/python/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/python/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,13 +39,13 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           uv pip install .[develop]
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation

--- a/python/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -39,14 +39,14 @@ jobs:
         run: |
           uv pip install dist/*.whl
           uv pip install dist/*.whl --target . --no-deps
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_run'
 
       - name: Install from source (manual trigger)
         run: |
           make develop
           uv pip install .
-          uv pip install "yardang[llms,themes]"
+          uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Build documentation


### PR DESCRIPTION
Remove the obsolete `llms` install extra from documentation workflows for all seven Python template variants. Yardang now ships its llms.txt builder directly, so generated projects only need the `themes` extra.

This affects both workflow-run artifact installs and manual source builds. Existing llms generation configuration remains unchanged.

Checked the complete template tree for remaining `yardang[llms…]` installs and ran `git diff --check`.
