### PR TITLE
Use lockless uv workflow for pure Python

### DIFF
--- a/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install from source (manual trigger)
         run: |
-          uv pip install --group dev -e .
+          uv pip install -e ".[develop]"
           uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 

--- a/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install from source (manual trigger)
         run: |
-          uv pip install .[develop]
+          uv pip install --group dev -e .
           uv pip install "yardang[themes]"
         if: github.event_name == 'workflow_dispatch'
 

--- a/python/pure/.gitignore.jinja
+++ b/python/pure/.gitignore.jinja
@@ -87,6 +87,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+uv.lock
 env/
 venv/
 ENV/

--- a/python/pure/Makefile.jinja
+++ b/python/pure/Makefile.jinja
@@ -4,10 +4,10 @@
 .PHONY: develop build install
 
 develop:  ## install dependencies and build library
-	uv pip install --group dev -e .
+	uv pip install -e ".[develop]"
 
 requirements:  ## install development dependencies
-	uv pip install --group dev
+	uv pip install -r pyproject.toml --extra develop
 
 build:  ## build the python library
 	uv build

--- a/python/pure/Makefile.jinja
+++ b/python/pure/Makefile.jinja
@@ -4,15 +4,13 @@
 .PHONY: develop build install
 
 develop:  ## install dependencies and build library
-	uv pip install -e .[develop]
+	uv pip install --group dev -e .
 
-requirements:  ## install prerequisite python build requirements
-	python -m pip install --upgrade pip toml
-	python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))'`
-	python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print(" ".join(c["project"]["optional-dependencies"]["develop"]))'`
+requirements:  ## install development dependencies
+	uv pip install --group dev
 
 build:  ## build the python library
-	python -m build -n
+	uv build
 
 install:  ## install library
 	uv pip install .
@@ -49,7 +47,8 @@ format: fix
 .PHONY: check-dist check-types checks check
 
 check-dist:  ## check python sdist and wheel with check-dist
-	check-dist -v
+	uv build
+	check-dist -v --pre-built dist
 
 check-types:  ## check python types with ty
 	ty check --python $$(which python)
@@ -96,10 +95,10 @@ major:  ## bump a major version
 .PHONY: dist dist-build dist-sdist dist-local-wheel publish
 
 dist-build:  # build python dists
-	python -m build -w -s
+	uv build
 
-dist-check:  ## run python dist checker with twine
-	python -m twine check dist/*
+dist-check:  ## check built python distributions
+	check-dist -v --pre-built dist
 
 dist: clean dist-build dist-check  ## build all dists
 

--- a/python/pure/pyproject.toml.jinja
+++ b/python/pure/pyproject.toml.jinja
@@ -37,8 +37,8 @@ classifiers = [
 
 dependencies = []
 
-[dependency-groups]
-dev = [
+[project.optional-dependencies]
+develop = [
     "bump-my-version",
     "check-dist",
     "codespell",

--- a/python/pure/pyproject.toml.jinja
+++ b/python/pure/pyproject.toml.jinja
@@ -37,22 +37,17 @@ classifiers = [
 
 dependencies = []
 
-[project.optional-dependencies]
-develop = [
-    "build",
+[dependency-groups]
+dev = [
     "bump-my-version",
     "check-dist",
     "codespell",
-    "hatchling",
     "mdformat",
     "mdformat-tables>=1",
     "pytest",
     "pytest-cov",
     "ruff",
-    "twine",
     "ty",
-    "uv",
-    "wheel",
 ]
 
 [project.scripts]

--- a/python/pure/{% if add_wiki %}docs{% endif %}/wiki/contribute/Build-from-Source.md.jinja
+++ b/python/pure/{% if add_wiki %}docs{% endif %}/wiki/contribute/Build-from-Source.md.jinja
@@ -38,7 +38,7 @@ cd {{ project_name_formatted }}
 
 ## Install Python dependencies
 
-Python development dependencies are specified in the `dev` dependency group in `pyproject.toml`. Install them with `uv`:
+Python development and test dependencies are published in the `develop` extra in `pyproject.toml`. Install them with `uv`:
 
 ```bash
 make requirements

--- a/python/pure/{% if add_wiki %}docs{% endif %}/wiki/contribute/Build-from-Source.md.jinja
+++ b/python/pure/{% if add_wiki %}docs{% endif %}/wiki/contribute/Build-from-Source.md.jinja
@@ -38,13 +38,13 @@ cd {{ project_name_formatted }}
 
 ## Install Python dependencies
 
-Python build and develop dependencies are specified in the `pyproject.toml`, but you can manually install them:
+Python development dependencies are specified in the `dev` dependency group in `pyproject.toml`. Install them with `uv`:
 
 ```bash
 make requirements
 ```
 
-Note that these dependencies would otherwise be installed normally as part of [PEP517](https://peps.python.org/pep-0517/) / [PEP518](https://peps.python.org/pep-0518/).
+Build dependencies are installed separately in an isolated environment as part of [PEP517](https://peps.python.org/pep-0517/) / [PEP518](https://peps.python.org/pep-0518/).
 
 ## Build
 

--- a/python/rust/rust/Makefile.jinja
+++ b/python/rust/rust/Makefile.jinja
@@ -3,8 +3,8 @@
 requirements:  ## install required dev dependencies
 	rustup component add rustfmt
 	rustup component add clippy
-	cargo install --locked --force cargo-nextest
-	cargo install --force cargo-llvm-cov
+	cargo install --locked cargo-nextest --version 0.9.143
+	cargo install --locked cargo-llvm-cov --version 0.8.7
 
 develop: requirements  ## install required dev dependencies
 


### PR DESCRIPTION
Pilots an end-to-end `uv` workflow in the pure Python template without committing a Python lockfile.

- Preserves the published `develop` extra so test and development dependencies remain installable with built artifacts.
- Uses lockless `uv pip` commands for source development and dependency installation.
- Uses `uv build` for isolated sdist and wheel creation, then checks those artifacts with `check-dist`.
- Removes redundant `build`, Hatchling, Twine, `uv`, and `wheel` development dependencies and updates generated documentation.

Rendered the pure template with Copier under Python 3.12 and ran `make requirements`, `make develop`, `make lint`, `make checks`, `make test`, and `make dist`. All passed, and no `uv.lock` was created.

Also installed the generated wheel with `[develop]` in a fresh environment outside the source checkout and ran its vendored test from `site-packages` successfully. Changes to artifact-test actions are intentionally out of scope.
