### PR TITLE
Update lockfiles during version bumps

### DIFF
--- a/python/cppjswasm/pyproject.toml.jinja
+++ b/python/cppjswasm/pyproject.toml.jinja
@@ -74,6 +74,10 @@ current_version = "0.1.0"
 commit = true
 tag = true
 commit_args = "-s"
+pre_commit_hooks = [
+    "pnpm --dir js install --lockfile-only --no-frozen-lockfile --ignore-scripts",
+    "git add js/pnpm-lock.yaml",
+]
 
 [[tool.bumpversion.files]]
 filename = "{{ module }}/__init__.py"

--- a/python/js/pyproject.toml.jinja
+++ b/python/js/pyproject.toml.jinja
@@ -68,6 +68,10 @@ current_version = "0.1.0"
 commit = true
 tag = true
 commit_args = "-s"
+pre_commit_hooks = [
+    "pnpm --dir js install --lockfile-only --no-frozen-lockfile --ignore-scripts",
+    "git add js/pnpm-lock.yaml",
+]
 
 [[tool.bumpversion.files]]
 filename = "{{ module }}/__init__.py"

--- a/python/jupyter/pyproject.toml.jinja
+++ b/python/jupyter/pyproject.toml.jinja
@@ -75,6 +75,10 @@ current_version = "0.1.0"
 commit = true
 tag = true
 commit_args = "-s"
+pre_commit_hooks = [
+    "pnpm --dir js install --lockfile-only --no-frozen-lockfile --ignore-scripts",
+    "git add js/pnpm-lock.yaml",
+]
 
 [[tool.bumpversion.files]]
 filename = "{{ module }}/__init__.py"

--- a/python/rust/pyproject.toml.jinja
+++ b/python/rust/pyproject.toml.jinja
@@ -70,6 +70,10 @@ current_version = "0.1.0"
 commit = true
 tag = true
 commit_args = "-s"
+pre_commit_hooks = [
+    "cargo update --workspace",
+    "git add Cargo.lock",
+]
 
 [[tool.bumpversion.files]]
 filename = "{{ module }}/__init__.py"

--- a/python/rustjswasm/pyproject.toml.jinja
+++ b/python/rustjswasm/pyproject.toml.jinja
@@ -72,6 +72,11 @@ current_version = "0.1.0"
 commit = true
 tag = true
 commit_args = "-s"
+pre_commit_hooks = [
+    "cargo update --workspace",
+    "pnpm --dir js install --lockfile-only --no-frozen-lockfile --ignore-scripts",
+    "git add Cargo.lock js/pnpm-lock.yaml",
+]
 
 [[tool.bumpversion.files]]
 filename = "{{ module }}/__init__.py"


### PR DESCRIPTION
Regenerates language lockfiles during bump-my-version's pre-commit phase.

- Uses `cargo update --workspace` for Rust workspaces so only workspace package identities move to the new version; unrelated crates sharing that version are untouched.
- Uses pnpm lockfile-only installs for JS hybrids, with scripts disabled and frozen mode overridden for CI bumps.
- Stages only `Cargo.lock` and `js/pnpm-lock.yaml` so generated changes join the version bump commit.

Verified by generating and patch-bumping the `js`, `jupyter`, `cppjswasm`, `rust`, and `rustjswasm` templates. Cargo workspace entries updated to 0.1.1, unrelated Jupyter dependencies at 0.1.0 remained unchanged, and every generated working tree was clean after the bump.
