### PR TITLE
Fix JavaScript build artifacts

### DIFF
--- a/python/cppjswasm/js/build.mjs.jinja
+++ b/python/cppjswasm/js/build.mjs.jinja
@@ -18,23 +18,39 @@ const BUNDLES = [
 ];
 
 async function build() {
+  if (fs.existsSync("dist")) {
+    for (const entry of fs.readdirSync("dist")) {
+      if (entry !== "pkg") {
+        fs.rmSync(`dist/${entry}`, { recursive: true, force: true });
+      }
+    }
+  }
+  fs.rmSync("../{{ module }}/extension", {
+    recursive: true,
+    force: true,
+  });
+
   // Bundle css
   await bundle_css();
 
   // Copy HTML
-  cpy("src/html/*", "dist/");
+  await cpy("src/html/*", "dist/");
 
   // Copy images
-  fs.mkdirSync("dist/img", { recursive: true });
-  cpy("src/img/*", "dist/img");
+  if (fs.existsSync("src/img")) {
+    fs.mkdirSync("dist/img", { recursive: true });
+    await cpy("src/img/*", "dist/img");
+  }
 
   await Promise.all(BUNDLES.map(bundle)).catch(() => process.exit(1));
 
   // Copy servable assets to python extension (exclude esm/)
   fs.mkdirSync("../{{ module }}/extension", { recursive: true });
-  cpy("dist/**/*", "../{{ module }}/extension", {
-    filter: (file) => !file.relativePath.startsWith("esm"),
+  await cpy("dist/**/*", "../{{ module }}/extension", {
+    filter: (file) =>
+      !file.relativePath.startsWith("esm/") &&
+      !file.relativePath.startsWith("dist/esm/"),
   });
 }
 
-build();
+await build();

--- a/python/cppjswasm/js/package.json.jinja
+++ b/python/cppjswasm/js/package.json.jinja
@@ -18,18 +18,19 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist/**/*",
-    "index.d.ts"
+    "dist/**/*"
   ],
   "types": "./dist/esm/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
+    "build:clean": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true}); fs.rmSync('../{{ module }}/extension',{recursive:true,force:true})\"",
     "build:cpp": "node -e \"require('fs').mkdirSync('dist/pkg',{recursive:true})\" && em++ -O2 -std=c++17 -s WASM=1 -s MODULARIZE=1 -s EXPORT_ES6=1 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s ENVIRONMENT=web,worker --bind -I ../cpp ../cpp/{{ project_name_formatted }}/example.cpp src/cpp/bindings.cpp -o dist/pkg/{{ module }}.js",
     "build:debug": "node build.mjs --debug",
     "build:prod": "node build.mjs",
-    "build": "npm-run-all build:cpp build:prod",
+    "build:types": "tsc",
+    "build": "npm-run-all build:clean build:cpp build:prod build:types",
     "clean": "rm -rf dist lib playwright-report ../{{ module }}/extension",
     "dev": "npm-run-all -p start watch",
     "lint:js": "oxlint . && oxfmt --check \"src/**/*.{js,ts,jsx,tsx,css}\" \"tests/**/*.{js,ts,jsx,tsx}\" \"*.mjs\" \"*.json\"",

--- a/python/cppjswasm/js/tsconfig.json
+++ b/python/cppjswasm/js/tsconfig.json
@@ -14,11 +14,11 @@
     "noFallthroughCasesInSwitch": true,
     "outDir": "./dist/esm",
     "resolveJsonModule": true,
-    "rootDir": ".",
+    "rootDir": "./src/ts",
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2020",
     "useDefineForClassFields": true
   },
-  "include": ["./src/ts/*.ts", "./tests/*.ts"]
+  "include": ["./src/ts/*.ts"]
 }

--- a/python/js/js/build.mjs.jinja
+++ b/python/js/js/build.mjs.jinja
@@ -18,23 +18,33 @@ const BUNDLES = [
 ];
 
 async function build() {
+  fs.rmSync("dist", { recursive: true, force: true });
+  fs.rmSync("../{{ module }}/extension", {
+    recursive: true,
+    force: true,
+  });
+
   // Bundle css
   await bundle_css();
 
   // Copy HTML
-  cpy("src/html/*", "dist/");
+  await cpy("src/html/*", "dist/");
 
   // Copy images
-  fs.mkdirSync("dist/img", { recursive: true });
-  cpy("src/img/*", "dist/img");
+  if (fs.existsSync("src/img")) {
+    fs.mkdirSync("dist/img", { recursive: true });
+    await cpy("src/img/*", "dist/img");
+  }
 
   await Promise.all(BUNDLES.map(bundle)).catch(() => process.exit(1));
 
   // Copy servable assets to python extension (exclude esm/)
   fs.mkdirSync("../{{ module }}/extension", { recursive: true });
-  cpy("dist/**/*", "../{{ module }}/extension", {
-    filter: (file) => !file.relativePath.startsWith("esm"),
+  await cpy("dist/**/*", "../{{ module }}/extension", {
+    filter: (file) =>
+      !file.relativePath.startsWith("esm/") &&
+      !file.relativePath.startsWith("dist/esm/"),
   });
 }
 
-build();
+await build();

--- a/python/js/js/package.json.jinja
+++ b/python/js/js/package.json.jinja
@@ -18,8 +18,7 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist/**/*",
-    "index.d.ts"
+    "dist/**/*"
   ],
   "types": "./dist/esm/index.d.ts",
   "publishConfig": {
@@ -27,7 +26,9 @@
   },
   "scripts": {
     "build:debug": "node build.mjs --debug",
-    "build": "node build.mjs",
+    "build:prod": "node build.mjs",
+    "build:types": "tsc",
+    "build": "npm-run-all build:prod build:types",
     "clean": "rm -rf dist playwright-report ../{{ module }}/extension",
     "dev": "npm-run-all -p start watch",
     "lint": "oxlint . && oxfmt --check \"src/**/*.{js,ts,jsx,tsx,css}\" \"tests/**/*.{js,ts,jsx,tsx}\" \"*.mjs\" \"*.json\"",

--- a/python/js/js/tsconfig.json
+++ b/python/js/js/tsconfig.json
@@ -14,11 +14,11 @@
     "noFallthroughCasesInSwitch": true,
     "outDir": "./dist/esm",
     "resolveJsonModule": true,
-    "rootDir": ".",
+    "rootDir": "./src/ts",
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2020",
     "useDefineForClassFields": true
   },
-  "include": ["./src/ts/*.ts", "./tests/*.ts"]
+  "include": ["./src/ts/*.ts"]
 }

--- a/python/rustjswasm/js/build.mjs.jinja
+++ b/python/rustjswasm/js/build.mjs.jinja
@@ -18,6 +18,18 @@ const BUNDLES = [
 ];
 
 async function build() {
+  if (fs.existsSync("dist")) {
+    for (const entry of fs.readdirSync("dist")) {
+      if (entry !== "pkg") {
+        fs.rmSync(`dist/${entry}`, { recursive: true, force: true });
+      }
+    }
+  }
+  fs.rmSync("../{{ module }}/extension", {
+    recursive: true,
+    force: true,
+  });
+
   // Bundle css
   await bundle_css();
 
@@ -33,10 +45,6 @@ async function build() {
   await Promise.all(BUNDLES.map(bundle)).catch(() => process.exit(1));
 
   // Copy servable assets to python extension (exclude esm/)
-  fs.rmSync("../{{ module }}/extension", {
-    recursive: true,
-    force: true,
-  });
   fs.mkdirSync("../{{ module }}/extension", { recursive: true });
   await cpy("dist/**/*", "../{{ module }}/extension", {
     filter: (file) =>
@@ -45,4 +53,4 @@ async function build() {
   });
 }
 
-build();
+await build();

--- a/python/rustjswasm/js/package.json.jinja
+++ b/python/rustjswasm/js/package.json.jinja
@@ -18,8 +18,7 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist/**/*",
-    "index.d.ts"
+    "dist/**/*"
   ],
   "types": "./dist/esm/index.d.ts",
   "publishConfig": {
@@ -27,11 +26,13 @@
   },
   "scripts": {
     "setup": "cargo install -f wasm-bindgen-cli --version 0.2.126 --locked",
+    "build:clean": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true}); fs.rmSync('../{{ module }}/extension',{recursive:true,force:true})\"",
     "build:debug": "node build.mjs --debug",
     "build:rust": "cargo build --release --all-features --target wasm32-unknown-unknown --target-dir ../target",
     "build:wasm-bindgen": "wasm-bindgen ../target/wasm32-unknown-unknown/release/{{ module }}.wasm --out-dir ./dist/pkg --target web",
     "build:prod": "node build.mjs",
-    "build": "npm-run-all build:rust build:wasm-bindgen build:prod",
+    "build:types": "tsc",
+    "build": "npm-run-all build:clean build:rust build:wasm-bindgen build:prod build:types",
     "clean": "rm -rf dist lib playwright-report ../{{ module }}/extension",
     "dev": "npm-run-all -p start watch",
     "lint:js": "oxlint . && oxfmt --check \"src/**/*.{js,ts,jsx,tsx,css}\" \"tests/**/*.{js,ts,jsx,tsx}\" \"*.mjs\" \"*.json\"",

--- a/python/rustjswasm/js/tsconfig.json
+++ b/python/rustjswasm/js/tsconfig.json
@@ -14,11 +14,11 @@
     "noFallthroughCasesInSwitch": true,
     "outDir": "./dist/esm",
     "resolveJsonModule": true,
-    "rootDir": ".",
+    "rootDir": "./src/ts",
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2020",
     "useDefineForClassFields": true
   },
-  "include": ["./src/ts/*.ts", "./tests/*.ts"]
+  "include": ["./src/ts/*.ts"]
 }


### PR DESCRIPTION
Corrects JavaScript artifact generation in the JS, Rust/JS/WASM, and C++/JS/WASM templates.

- Runs TypeScript declaration emission after bundling and aligns `rootDir` so the exported `dist/esm/index.d.ts` is actually generated and packed.
- Clears stale distribution and Python-extension assets before rebuilding, while preserving freshly generated WASM `dist/pkg` during esbuild passes.
- Fixes ESM filtering so ESM-only output is not copied into Python extension assets.
- Awaits all cpy operations and the top-level build promise so copy failures and completion are deterministic.

Verified in freshly generated projects for all three variants. Plain JS passed full build, pack, stale-sentinel, and Oxlint/Oxfmt checks. Rust/JS/WASM passed a full native Cargo + wasm-bindgen build and pack check. C++/JS/WASM passed cleanup, esbuild, TypeScript, pack, and lint checks with a generated-module fixture because Emscripten is not installed locally.
