### PR TITLE
Add Linux ARM wheel builds

### DIFF
--- a/python/cpp/.github/workflows/build.yaml.jinja
+++ b/python/cpp/.github/workflows/build.yaml.jinja
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         python:
           {% if python_version_primary == "3.10" -%}
           - version: "3.10"
@@ -104,7 +104,7 @@ jobs:
       - name: Install build dependencies
         run: pip install cibuildwheel
 
-      - name: Build distributions (Linux)
+      - name: Build distributions (Linux x86_64)
         run: |
           rm -rf dist
           make dist-py-sdist
@@ -112,8 +112,20 @@ jobs:
           make dist-check
         env:
           CIBW_BUILD: {% raw %}"${{ matrix.python.cibuildwheel }}-manylinux*"{% endraw %}
+          CIBW_ARCHS_LINUX: native
           CIBW_BUILD_VERBOSITY: 3
         if: matrix.os == 'ubuntu-latest'
+
+      - name: Build distributions (Linux ARM64)
+        run: |
+          rm -rf dist
+          make dist-py-wheel
+          make dist-check
+        env:
+          CIBW_BUILD: {% raw %}"${{ matrix.python.cibuildwheel }}-manylinux*"{% endraw %}
+          CIBW_ARCHS_LINUX: native
+          CIBW_BUILD_VERBOSITY: 3
+        if: matrix.os == 'ubuntu-24.04-arm'
 
       - name: Build distributions (macOS)
         run: |
@@ -136,7 +148,7 @@ jobs:
         uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
 
       - name: Test source distribution
         uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446

--- a/python/cpp/pyproject.toml.jinja
+++ b/python/cpp/pyproject.toml.jinja
@@ -84,12 +84,13 @@ replace = 'version = "{new_version}"'
 
 [tool.cibuildwheel]
 build = "{% if python_version_primary == '3.10' %}cp310-* {% endif %}{% if python_version_primary in ['3.10', '3.11'] %}cp311-* {% endif %}{% if python_version_primary in ['3.10', '3.11', '3.12'] %}cp312-* {% endif %}cp313-*"
-test-command = "echo 'TODO'"
+test-command = "pytest -vvv {project}/{{ module }}/tests"
 test-extras = "develop"
 
 [tool.cibuildwheel.linux]
+manylinux-aarch64-image = "manylinux_2_28"
 manylinux-x86_64-image = "manylinux_2_28"
-skip = "*i686 musllinux*"
+skip = "*i686* *musllinux*"
 
 [tool.cibuildwheel.macos]
 environment = {MACOSX_DEPLOYMENT_TARGET="11.0"}

--- a/python/cppjswasm/.github/workflows/build.yaml.jinja
+++ b/python/cppjswasm/.github/workflows/build.yaml.jinja
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -93,7 +93,7 @@ jobs:
       - name: Install build dependencies
         run: pip install cibuildwheel
 
-      - name: Build distributions (Linux)
+      - name: Build distributions (Linux x86_64)
         run: |
           rm -rf dist
           make dist-py-sdist
@@ -101,8 +101,20 @@ jobs:
           make dist-check
         env:
           CIBW_BUILD: "cp{{ python_version_primary.replace('.', '') }}-manylinux*"
+          CIBW_ARCHS_LINUX: native
           CIBW_BUILD_VERBOSITY: 3
         if: matrix.os == 'ubuntu-latest'
+
+      - name: Build distributions (Linux ARM64)
+        run: |
+          rm -rf dist
+          make dist-py-wheel
+          make dist-check
+        env:
+          CIBW_BUILD: "cp{{ python_version_primary.replace('.', '') }}-manylinux*"
+          CIBW_ARCHS_LINUX: native
+          CIBW_BUILD_VERBOSITY: 3
+        if: matrix.os == 'ubuntu-24.04-arm'
 
       - name: Build distributions (macOS)
         run: |
@@ -125,7 +137,7 @@ jobs:
         uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
 
       - name: Test source distribution
         uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446

--- a/python/rust/.github/workflows/build.yaml.jinja
+++ b/python/rust/.github/workflows/build.yaml.jinja
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -79,20 +79,14 @@ jobs:
         with:
           token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
-        with:
-          platforms: all
-        if: runner.os == 'Linux' && runner.arch == 'X64'
-
       - name: Free disk space
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/share/swift
           df -h /
         shell: bash
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
 
-      - name: Build distributions (Linux)
+      - name: Build distributions (Linux x86_64)
         run: |
           rm -rf dist
           make dist-rs
@@ -100,7 +94,19 @@ jobs:
           make dist-py-wheel
           make dist-check
         shell: bash
+        env:
+          CIBW_ARCHS_LINUX: native
         if: matrix.os == 'ubuntu-latest'
+
+      - name: Build distributions (Linux ARM64)
+        run: |
+          rm -rf dist
+          make dist-py-wheel
+          make dist-check
+        shell: bash
+        env:
+          CIBW_ARCHS_LINUX: native
+        if: matrix.os == 'ubuntu-24.04-arm'
 
       - name: Build distributions (macOS/Windows)
         run: |
@@ -110,13 +116,13 @@ jobs:
         shell: bash
         env:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
-        if: matrix.os != 'ubuntu-latest'
+        if: runner.os != 'Linux'
 
       - name: Test wheel
         uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
 
       - name: Test source distribution
         uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446

--- a/python/rustjswasm/.github/workflows/build.yaml.jinja
+++ b/python/rustjswasm/.github/workflows/build.yaml.jinja
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -85,20 +85,14 @@ jobs:
         with:
           token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
-        with:
-          platforms: all
-        if: runner.os == 'Linux' && runner.arch == 'X64'
-
       - name: Free disk space
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/share/swift
           df -h /
         shell: bash
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
 
-      - name: Build distributions (Linux)
+      - name: Build distributions (Linux x86_64)
         run: |
           rm -rf dist
           make dist-rs
@@ -106,7 +100,19 @@ jobs:
           make dist-py-wheel
           make dist-check
         shell: bash
+        env:
+          CIBW_ARCHS_LINUX: native
         if: matrix.os == 'ubuntu-latest'
+
+      - name: Build distributions (Linux ARM64)
+        run: |
+          rm -rf dist
+          make dist-py-wheel
+          make dist-check
+        shell: bash
+        env:
+          CIBW_ARCHS_LINUX: native
+        if: matrix.os == 'ubuntu-24.04-arm'
 
       - name: Build distributions (macOS/Windows)
         run: |
@@ -116,13 +122,13 @@ jobs:
         shell: bash
         env:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
-        if: matrix.os != 'ubuntu-latest'
+        if: runner.os != 'Linux'
 
       - name: Test wheel
         uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: {{module}}
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
 
       - name: Test source distribution
         uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446


### PR DESCRIPTION
Adds native Linux ARM64 coverage to the C++, Rust, Rust/JS/WASM, and C++/JS/WASM generated workflows.

`ubuntu-24.04-arm` now participates as a full CI platform: dependency installation, host build, tests and coverage, native `manylinux_aarch64` wheel generation, cibuildwheel's in-container tests, installed-wheel smoke testing, and artifact upload. Source distributions and Rust crate packages remain x86 Linux-only to avoid duplicate source artifacts.

The workflows use `CIBW_ARCHS_LINUX=native`, remove obsolete QEMU setup from Rust variants, and give ARM artifacts a distinct runner-qualified name. The C++ template also aligns its ARM image with `manylinux_2_28`, replaces its placeholder cibuildwheel test with vendored pytest tests, and fixes the existing musllinux skip selector.

Verified by generating all four templates, parsing each rendered workflow as YAML, and asking cibuildwheel 3.4.1 for both architecture plans. Every variant selected exactly `manylinux_x86_64` and `manylinux_aarch64`, with no musllinux builds.
