### PR TITLE
Clean stale Pyodide wheels before builds

### DIFF
--- a/python/cpp/Makefile.jinja
+++ b/python/cpp/Makefile.jinja
@@ -88,6 +88,7 @@ coverage-py:  ## run python tests and collect test coverage
 test: test-py  ## run all tests
 {% if add_pyodide %}
 test-pyodide:  ## build and test the Python package in Pyodide
+	rm -rf dist/pyodide
 	uvx --from cibuildwheel==4.2.0 cibuildwheel --only cp314-pyodide_wasm32 --output-dir dist/pyodide .
 {% endif %}
 coverage: coverage-py  ## run all tests and collect test coverage

--- a/python/cppjswasm/Makefile.jinja
+++ b/python/cppjswasm/Makefile.jinja
@@ -140,6 +140,7 @@ coverage-cpp:  ## run C++ tests and collect test coverage
 test: test-py test-js test-cpp  ## run all tests
 {% if add_pyodide %}
 test-pyodide:  ## build and test the Python package in Pyodide
+	rm -rf dist/pyodide
 	uvx --from cibuildwheel==4.2.0 cibuildwheel --only cp314-pyodide_wasm32 --output-dir dist/pyodide .
 {% endif %}
 coverage: coverage-py coverage-js coverage-cpp  ## run all tests and collect test coverage

--- a/python/rust/Makefile.jinja
+++ b/python/rust/Makefile.jinja
@@ -115,6 +115,7 @@ test: test-py test-rs  ## run all tests
 {% if add_pyodide %}
 test-pyodide:  ## build and test the Python package in Pyodide
 	rustup target add wasm32-unknown-emscripten
+	rm -rf dist/pyodide
 	uvx --from cibuildwheel==4.2.0 cibuildwheel --only cp314-pyodide_wasm32 --output-dir dist/pyodide .
 {% endif %}
 coverage: coverage-py coverage-rs  ## run all tests and collect test coverage

--- a/python/rustjswasm/Makefile.jinja
+++ b/python/rustjswasm/Makefile.jinja
@@ -138,6 +138,7 @@ test: test-py test-js test-rs  ## run all tests
 {% if add_pyodide %}
 test-pyodide:  ## build and test the Python package in Pyodide
 	rustup target add wasm32-unknown-emscripten
+	rm -rf dist/pyodide
 	uvx --from cibuildwheel==4.2.0 cibuildwheel --only cp314-pyodide_wasm32 --output-dir dist/pyodide .
 {% endif %}
 coverage: coverage-py coverage-js coverage-rs  ## run all tests and collect test coverage


### PR DESCRIPTION
Propagates the stale-wheel fix from transports to all four Pyodide-capable templates: C++, Rust, C++/JS/WASM, and Rust/JS/WASM.

Each opt-in `test-pyodide` target now removes `dist/pyodide` before invoking cibuildwheel. This prevents wheels from an earlier package version remaining in the output directory and being uploaded or selected by downstream tooling.

Rendered all four templates with Pyodide enabled and verified the generated recipes with `make -n test-pyodide`.
