### PR TITLE
Fix Pyodide TOML spacing

### DIFF
--- a/python/cpp/pyproject.toml.jinja
+++ b/python/cpp/pyproject.toml.jinja
@@ -105,8 +105,7 @@ skip = "*win32 *arm_64"
 test-command = "python -m pytest -vvv --pyargs {{ module }}.tests"
 test-extras = []
 test-requires = ["pytest"]
-{% endif -%}
-
+{% endif %}
 [tool.coverage.run]
 branch = true
 omit = [

--- a/python/cppjswasm/pyproject.toml.jinja
+++ b/python/cppjswasm/pyproject.toml.jinja
@@ -117,8 +117,7 @@ environment = {SKIP_HATCH_JS="1"}
 test-command = "python -m pytest -vvv --pyargs {{ module }}.tests"
 test-extras = []
 test-requires = ["pytest"]
-{% endif -%}
-
+{% endif %}
 [tool.coverage.run]
 branch = true
 omit = [


### PR DESCRIPTION
Ensure generated C++ and C++/JS/WASM pyproject.toml files retain a blank line between the optional cibuildwheel Pyodide table and coverage configuration.\n\nRendered all four Pyodide-enabled variants and verified the table separation.