### PR TITLE
Clean Rust artifacts before Linux wheel builds

### DIFF
--- a/python/rust/pyproject.toml.jinja
+++ b/python/rust/pyproject.toml.jinja
@@ -107,6 +107,7 @@ rustup target add aarch64-unknown-linux-gnu
 rustup target add x86_64-unknown-linux-gnu
 rustup show
 """
+before-build = "cargo clean --manifest-path {package}/Cargo.toml && rm -f {package}/{{ module }}/*.so"
 environment = {PATH="$HOME/.cargo/bin:$PATH", CARGO_TERM_COLOR="always"}
 skip = "*i686* *musllinux*"
 

--- a/python/rustjswasm/pyproject.toml.jinja
+++ b/python/rustjswasm/pyproject.toml.jinja
@@ -119,6 +119,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=m
 rustup target add aarch64-unknown-linux-gnu
 rustup target add x86_64-unknown-linux-gnu
 """
+before-build = "cargo clean --manifest-path {package}/Cargo.toml && rm -f {package}/{{ module }}/*.so"
 environment = {PATH="$HOME/.cargo/bin:$PATH", CARGO_TERM_COLOR="always", SKIP_HATCH_JS="1" }
 skip = "*i686* *musllinux*"
 


### PR DESCRIPTION
Clean Cargo build cache and host-built package shared objects inside cibuildwheel's Linux container before each Rust wheel build. This prevents Ubuntu 24.04 ARM artifacts from being reused in manylinux_2_28_aarch64 wheels and rejected by auditwheel for newer glibc symbols.\n\nApplied to rust and rustjswasm. Rendered both templates, parsed generated TOML, exercised artifact cleanup with temporary fixtures, and resolved the aarch64 cibuildwheel identifiers.