### PR TITLE
Add theme system, error page, and sitemap to SvelteKit site template

### DIFF
--- a/javascript/site-sveltekit/README.md.jinja
+++ b/javascript/site-sveltekit/README.md.jinja
@@ -18,4 +18,7 @@ pnpm test
 pnpm build
 ```
 
+Visual regression snapshots live beside `tests/visual/` and are skipped when `CI` is set. Record or
+refresh them locally with `pnpm test:e2e:update`.
+
 This site uses SvelteKit's `adapter-{{ site_adapter }}` deployment adapter.

--- a/javascript/site-sveltekit/playwright.config.ts.jinja
+++ b/javascript/site-sveltekit/playwright.config.ts.jinja
@@ -2,10 +2,16 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: 'tests',
+  testMatch: ['**/*.spec.ts'],
+  testIgnore: process.env.CI ? ['**/visual/**'] : [],
+  snapshotPathTemplate: '{testDir}/{testFilePath}-snapshots/{arg}-{projectName}{ext}',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',
+  expect: {
+    toHaveScreenshot: { maxDiffPixelRatio: 0.01, threshold: 0.2, animations: 'disabled', caret: 'hide' }
+  },
   use: {
     baseURL: 'http://127.0.0.1:4177',
     trace: 'retain-on-failure',
@@ -18,9 +24,7 @@ export default defineConfig({
     timeout: 120_000
   },
   projects: [
-    {
-      name: 'desktop',
-      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 800 } }
-    }
+    { name: 'desktop', use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 800 } } },
+    { name: 'mobile', use: { ...devices['Desktop Chrome'], viewport: { width: 390, height: 844 } } }
   ]
 });

--- a/javascript/site-sveltekit/src/app.css.jinja
+++ b/javascript/site-sveltekit/src/app.css.jinja
@@ -1,13 +1,35 @@
 @import 'tailwindcss';
 
 :root {
-  color: #171717;
-  background: #ffffff;
-  font-family: system-ui, sans-serif;
+  --paper: #ffffff;
+  --ink: #171717;
+  --muted: #5c5c5c;
+  --line: #e4e4e4;
+
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  --paper: #0b0b0b;
+  --ink: #f2f2f2;
+  --muted: #a1a1a1;
+  --line: #262626;
+
+  color-scheme: dark;
+}
+
+@theme inline {
+  --color-paper: var(--paper);
+  --color-ink: var(--ink);
+  --color-muted: var(--muted);
+  --color-line: var(--line);
 }
 
 body {
   margin: 0;
+  color: var(--ink);
+  background: var(--paper);
+  font-family: system-ui, sans-serif;
 }
 
 a {

--- a/javascript/site-sveltekit/src/app.html.jinja
+++ b/javascript/site-sveltekit/src/app.html.jinja
@@ -4,6 +4,26 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#ffffff" />
+    <script>
+      try {
+        const savedTheme = localStorage.getItem('theme');
+        const theme =
+          savedTheme === 'light' || savedTheme === 'dark'
+            ? savedTheme
+            : matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light';
+
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.style.colorScheme = theme;
+        document
+          .querySelector('meta[name="theme-color"]')
+          ?.setAttribute('content', theme === 'dark' ? '#0b0b0b' : '#ffffff');
+      } catch {
+        // Use the light theme when browser storage is unavailable.
+      }
+    </script>
+    <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/javascript/site-sveltekit/src/routes/+error.svelte.jinja
+++ b/javascript/site-sveltekit/src/routes/+error.svelte.jinja
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { page } from '$app/state';
+</script>
+
+<svelte:head>
+  <title>{page.status} — {{ brand_name }}</title>
+</svelte:head>
+
+<main class="mx-auto grid min-h-[70vh] max-w-5xl place-items-center px-6 py-24 text-center">
+  <div>
+    <p class="text-sm uppercase tracking-widest text-muted">Error / {page.status}</p>
+    <h1 class="mt-6 text-5xl font-semibold tracking-tight sm:text-7xl">This path went quiet.</h1>
+    <p class="mx-auto mt-6 max-w-md leading-relaxed text-muted">
+      {page.error?.message ?? 'The page could not be found.'}
+    </p>
+    <a class="mt-9 inline-block text-sm font-semibold underline" href="/">Return home →</a>
+  </div>
+</main>

--- a/javascript/site-sveltekit/src/routes/+layout.svelte.jinja
+++ b/javascript/site-sveltekit/src/routes/+layout.svelte.jinja
@@ -1,7 +1,29 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import '../app.css';
 
   let { children } = $props();
+
+  let theme = $state<'light' | 'dark'>('light');
+
+  onMount(() => {
+    theme = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+  });
+
+  const toggleTheme = () => {
+    theme = theme === 'dark' ? 'light' : 'dark';
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute('content', theme === 'dark' ? '#0b0b0b' : '#ffffff');
+
+    try {
+      localStorage.setItem('theme', theme);
+    } catch {
+      // Keep the in-page theme when browser storage is unavailable.
+    }
+  };
 </script>
 
 <svelte:head>
@@ -12,5 +34,15 @@
   <meta property="og:description" content="{{ project_description }}" />
   <meta property="og:url" content="{{ site_url }}" />
 </svelte:head>
+
+<button
+  class="fixed right-5 top-5 z-50 rounded-full border border-line bg-paper px-4 py-2 text-xs font-semibold text-muted"
+  type="button"
+  data-testid="theme-toggle"
+  aria-label="Switch to {theme === 'dark' ? 'light' : 'dark'} theme"
+  onclick={toggleTheme}
+>
+  {theme === 'dark' ? 'Light' : 'Dark'}
+</button>
 
 {@render children()}

--- a/javascript/site-sveltekit/src/routes/+layout.ts.jinja
+++ b/javascript/site-sveltekit/src/routes/+layout.ts.jinja
@@ -1,1 +1,4 @@
 export const prerender = {{ 'true' if site_adapter == 'static' else 'false' }};
+{%- if site_adapter == 'static' %}
+export const trailingSlash = 'always';
+{%- endif %}

--- a/javascript/site-sveltekit/src/routes/sitemap.xml/+server.ts.jinja
+++ b/javascript/site-sveltekit/src/routes/sitemap.xml/+server.ts.jinja
@@ -1,0 +1,18 @@
+import type { RequestHandler } from './$types';
+
+export const prerender = true;
+
+const pages = [''];
+
+export const GET: RequestHandler = () => {
+  const urls = pages.map((page) => `<url><loc>{{ site_url }}/${page}</loc></url>`).join('');
+
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`,
+    {
+      headers: {
+        'Content-Type': 'application/xml'
+      }
+    }
+  );
+};

--- a/javascript/site-sveltekit/static/favicon.svg.jinja
+++ b/javascript/site-sveltekit/static/favicon.svg.jinja
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="{{ brand_name }}">
+  <rect width="64" height="64" rx="14" fill="#171717" />
+  <text
+    x="50%"
+    y="50%"
+    dy="0.35em"
+    text-anchor="middle"
+    fill="#ffffff"
+    font-family="system-ui, sans-serif"
+    font-size="34"
+    font-weight="600"
+  >{{ brand_name[0] | upper }}</text>
+</svg>

--- a/javascript/site-sveltekit/tests/a11y/audit.spec.ts.jinja
+++ b/javascript/site-sveltekit/tests/a11y/audit.spec.ts.jinja
@@ -1,10 +1,21 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test('home page has no automatically detectable accessibility violations', async ({ page }) => {
-  await page.goto('/');
-  await expect(page).toHaveTitle('{{ brand_name }}');
+const routes = ['/'];
 
-  const results = await new AxeBuilder({ page }).analyze();
-  expect(results.violations).toEqual([]);
-});
+for (const route of routes) {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${route} has no serious or critical accessibility violations in ${theme} mode`, async ({ page }) => {
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.addInitScript((value) => localStorage.setItem('theme', value), theme);
+      await page.goto(route);
+
+      const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']).analyze();
+      const violations = results.violations.filter((violation) =>
+        ['serious', 'critical'].includes(violation.impact ?? '')
+      );
+
+      expect(violations).toEqual([]);
+    });
+  }
+}

--- a/javascript/site-sveltekit/tests/behavior/theme.spec.ts.jinja
+++ b/javascript/site-sveltekit/tests/behavior/theme.spec.ts.jinja
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test('theme selection persists across navigation', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.removeItem('theme'));
+  await page.reload();
+
+  const initial = await page.locator('html').getAttribute('data-theme');
+  await page.getByTestId('theme-toggle').click();
+  const expected = initial === 'dark' ? 'light' : 'dark';
+
+  await expect(page.locator('html')).toHaveAttribute('data-theme', expected);
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', expected);
+});

--- a/javascript/site-sveltekit/tests/visual/pages.spec.ts.jinja
+++ b/javascript/site-sveltekit/tests/visual/pages.spec.ts.jinja
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+const routes = [{ name: 'home', path: '/' }];
+
+for (const route of routes) {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${route.name} in ${theme} mode`, async ({ page }) => {
+      await page.addInitScript((value) => localStorage.setItem('theme', value), theme);
+      await page.goto(route.path);
+      await expect(page).toHaveScreenshot(`${route.name}-${theme}.png`, { fullPage: true });
+    });
+  }
+}


### PR DESCRIPTION
Brings the SvelteKit site template up to the shape the personal site had grown into on its own, so future sites inherit it instead of rebuilding it.

- Persisted light/dark theme: an inline `app.html` script resolves `localStorage` then `prefers-color-scheme` before paint (no flash), and a toggle in the layout keeps `data-theme`, `color-scheme`, and the `theme-color` meta in sync.
- `app.css` moves to CSS custom property tokens (`paper`, `ink`, `muted`, `line`) exposed to Tailwind v4 via `@theme inline`.
- Adds `+error.svelte`, a prerendered `sitemap.xml` endpoint, and a brand-initial `favicon.svg`.
- `+layout.ts` sets `trailingSlash` for the static adapter.
- Playwright gains a mobile viewport and visual regression snapshots. Visual specs are skipped when `CI` is set, since baselines are machine-specific and none ship with the template; record them locally with `pnpm test:e2e:update`.
- The accessibility audit now runs in both themes with reduced motion, and filters to serious and critical violations.