### PR TITLE
Allow @parcel/watcher build script in Jupyter template

### DIFF
--- a/python/jupyter/js/pnpm-workspace.yaml
+++ b/python/jupyter/js/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   "@fortawesome/fontawesome-free": true
+  "@parcel/watcher": true
   unrs-resolver: true
 
 overrides:


### PR DESCRIPTION
The Jupyter template's `make requirements-js` currently fails on `pnpm install`:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.6.0
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
make[1]: *** [Makefile:19: requirements-js] Error 1
```

`jest@30.5.0` now pulls `@parcel/watcher` in through `jest-haste-map` (confirmed with `pnpm why`). It has a build script, and pnpm refuses to skip one silently unless the package is listed in `allowBuilds`, so the install exits non-zero.

Adding it alongside the existing entries fixes it. `@parcel/watcher` resolves a prebuilt platform package rather than compiling, so this does not add a native build step.

This is dependency drift rather than a regression from any particular change: main was green on 2026-08-27 and the same failure now reproduces on unrelated branches. Only the Jupyter template is affected; the other JavaScript templates allow just `esbuild` and are unaffected.

Verified with `make gen-jupyter`, then in the generated project: `pnpm install` succeeds, `pnpm lint` passes, and `pnpm test` passes 2/2. Also confirmed `@parcel/watcher` loads at runtime.