### PR TITLE
Update actions-ext pins across templates and CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
           printf 'fn main() {\n    println!("Hello, world!");\n}\n' > src/main.rs
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: '3.11'
 
@@ -90,7 +90,7 @@ jobs:
         if: matrix.template == 'cpp' || matrix.template == 'cppjswasm'
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
+        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
         with:
           version: 22.x
           pnpm_version: 11.11.0
@@ -98,7 +98,7 @@ jobs:
         if: matrix.template == 'js' || matrix.template == 'jupyter' || matrix.template == 'cppjswasm' || matrix.template == 'rustjswasm' || matrix.template == 'uitk-svelte' || matrix.template == 'uitk-webawesome' || matrix.template == 'site-react' || matrix.template == 'site-sveltekit' || matrix.template == 'site-webawesome'
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
+        uses: actions-ext/rust/setup@3de300f3071e758a1dd8545b884288a35e5d7f81
         if: matrix.template == 'rust' || matrix.template == 'rustjswasm'
 
       - name: Install JavaScript dependencies

--- a/python/cpp/.github/workflows/build.yaml.jinja
+++ b/python/cpp/.github/workflows/build.yaml.jinja
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: {% raw %}${{ matrix.python.version }}{% endraw %}
 
@@ -176,13 +176,13 @@ jobs:
         if: matrix.platform.name == 'windows-latest'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.platform.name == 'ubuntu-latest'

--- a/python/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/cppjswasm/.github/workflows/build.yaml.jinja
+++ b/python/cppjswasm/.github/workflows/build.yaml.jinja
@@ -66,12 +66,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: {% raw %}${{ matrix.python }}{% endraw %}
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
+        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
         with:
           version: 22.x
         if: matrix.target == 'native'
@@ -172,13 +172,13 @@ jobs:
         if: matrix.name == 'windows-latest'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.name == 'ubuntu-latest'

--- a/python/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/js/.github/workflows/build.yaml.jinja
+++ b/python/js/.github/workflows/build.yaml.jinja
@@ -34,12 +34,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: "{{ python_version_primary }}"
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
+        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
         with:
           version: 22.x
 
@@ -79,12 +79,12 @@ jobs:
         run: make dist
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
 

--- a/python/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/jupyter/.github/workflows/build.yaml.jinja
+++ b/python/jupyter/.github/workflows/build.yaml.jinja
@@ -34,12 +34,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: "{{ python_version_primary }}"
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
+        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
         with:
           version: 22.x
 
@@ -79,12 +79,12 @@ jobs:
         run: make dist
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
 

--- a/python/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/pure/.github/workflows/build.yaml.jinja
+++ b/python/pure/.github/workflows/build.yaml.jinja
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: "{{ python_version_primary }}"
 
@@ -74,12 +74,12 @@ jobs:
         run: make dist
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
 

--- a/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/rust/.github/workflows/build.yaml.jinja
+++ b/python/rust/.github/workflows/build.yaml.jinja
@@ -66,12 +66,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: {% raw %}${{ matrix.python }}{% endraw %}
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
+        uses: actions-ext/rust/setup@3de300f3071e758a1dd8545b884288a35e5d7f81
 
       - name: Install dependencies
         run: make develop
@@ -156,13 +156,13 @@ jobs:
         if: matrix.target == 'native' && runner.os != 'Linux'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.name == 'ubuntu-latest'

--- a/python/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/rustjswasm/.github/workflows/build.yaml.jinja
+++ b/python/rustjswasm/.github/workflows/build.yaml.jinja
@@ -66,15 +66,15 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           version: {% raw %}${{ matrix.python }}{% endraw %}
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
+        uses: actions-ext/rust/setup@3de300f3071e758a1dd8545b884288a35e5d7f81
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@0ea5bdcd24d2488b28e16bf611b446a2f8e1e12f
+        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
         with:
           version: 22.x
         if: matrix.target == 'native'
@@ -162,13 +162,13 @@ jobs:
         if: matrix.target == 'native' && runner.os != 'Linux'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
         with:
           module: {{module}}
         if: matrix.name == 'ubuntu-latest'

--- a/python/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
+        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8


### PR DESCRIPTION
Every `uses:` reference in the repo is now pinned to the newest available
version. Verified repo-wide: 15 distinct actions, 0 stale, 0 unpinned.

All third-party actions were already current, with every SHA correctly
matching its `# vX` comment. The only stale pins were the internal
`actions-ext/*` references:

| action | from | to | note |
| --- | --- | --- | --- |
| `actions-ext/python/{setup,test-wheel,test-sdist}` | `6e1b91a` | `a3f3953` | 2 commits, own CI bump only |
| `actions-ext/node/setup` | `0ea5bdc` | `b0536d8` | picks up the pnpm version selection fixes |
| `actions-ext/rust/setup` | `2db8e3e` | `3de300f` | 2 commits, own CI bump only |

These appeared in the Python templates and in this repo's own
`.github/workflows/build.yaml`, split across two commits.

The `javascript/` templates and `actions-ext/cpp/*` were already at main.
`apps/` is empty, so there was nothing to update there.
