### PR TITLE
Update wasm-bindgen to 0.2.127

### DIFF
--- a/python/rustjswasm/js/Cargo.toml.jinja
+++ b/python/rustjswasm/js/Cargo.toml.jinja
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 {{ module }} = { path = "../rust", version = "*" }
-wasm-bindgen = "=0.2.126"
+wasm-bindgen = "=0.2.127"

--- a/python/rustjswasm/js/package.json.jinja
+++ b/python/rustjswasm/js/package.json.jinja
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "scripts": {
-    "setup": "cargo install -f wasm-bindgen-cli --version 0.2.126 --locked",
+    "setup": "cargo install -f wasm-bindgen-cli --version 0.2.127 --locked",
     "build:clean": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true}); fs.rmSync('../{{ module }}/extension',{recursive:true,force:true})\"",
     "build:debug": "node build.mjs --debug",
     "build:rust": "cargo build --release --all-features --target wasm32-unknown-unknown --target-dir ../target",

--- a/python/rustjswasm/rust/Makefile.jinja
+++ b/python/rustjswasm/rust/Makefile.jinja
@@ -5,7 +5,7 @@ requirements:  ## install required dev dependencies
 	rustup component add clippy
 	cargo install --force --locked cargo-nextest
 	cargo install --force --locked cargo-llvm-cov
-	cargo install --force --locked wasm-bindgen-cli --version 0.2.126
+	cargo install --force --locked wasm-bindgen-cli --version 0.2.127
 	rustup target add wasm32-unknown-unknown
 
 develop: requirements  ## install required dev dependencies


### PR DESCRIPTION
Bumps wasm-bindgen from 0.2.126 to 0.2.127 in the `rustjswasm` template.

The crate and the CLI must be on the exact same version, so all three
pins move together:

| file | pin |
| --- | --- |
| `js/Cargo.toml.jinja` | `wasm-bindgen = "=0.2.127"` |
| `js/package.json.jinja` | `setup` script — `wasm-bindgen-cli --version 0.2.127` |
| `rust/Makefile.jinja` | `requirements` target — `wasm-bindgen-cli --version 0.2.127` |

`rustjswasm` is the only template that uses wasm-bindgen; `cppjswasm` goes
through emsdk instead.