### PR TITLE
Re-pin actions-ext references to current main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
           printf 'fn main() {\n    println!("Hello, world!");\n}\n' > src/main.rs
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: '3.11'
 
@@ -90,7 +90,7 @@ jobs:
         if: matrix.template == 'cpp' || matrix.template == 'cppjswasm'
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
           pnpm_version: 11.11.0
@@ -98,7 +98,7 @@ jobs:
         if: matrix.template == 'js' || matrix.template == 'jupyter' || matrix.template == 'cppjswasm' || matrix.template == 'rustjswasm' || matrix.template == 'uitk-svelte' || matrix.template == 'uitk-webawesome' || matrix.template == 'site-react' || matrix.template == 'site-sveltekit' || matrix.template == 'site-webawesome'
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@3de300f3071e758a1dd8545b884288a35e5d7f81
+        uses: actions-ext/rust/setup@0f0b7c9ab3cdb6e9a1f79e2147974d6762ddafea
         if: matrix.template == 'rust' || matrix.template == 'rustjswasm'
 
       - name: Install JavaScript dependencies

--- a/javascript/site-react/.github/workflows/build.yaml.jinja
+++ b/javascript/site-react/.github/workflows/build.yaml.jinja
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
           js_folder: .

--- a/javascript/site-sveltekit/.github/workflows/build.yaml.jinja
+++ b/javascript/site-sveltekit/.github/workflows/build.yaml.jinja
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
           js_folder: .

--- a/javascript/site-webawesome/.github/workflows/build.yaml.jinja
+++ b/javascript/site-webawesome/.github/workflows/build.yaml.jinja
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
           js_folder: .

--- a/javascript/uitk-svelte/.github/workflows/build.yaml.jinja
+++ b/javascript/uitk-svelte/.github/workflows/build.yaml.jinja
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
           js_folder: .

--- a/javascript/uitk-webawesome/.github/workflows/build.yaml.jinja
+++ b/javascript/uitk-webawesome/.github/workflows/build.yaml.jinja
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
           js_folder: .

--- a/python/cpp/.github/workflows/build.yaml.jinja
+++ b/python/cpp/.github/workflows/build.yaml.jinja
@@ -80,16 +80,16 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: {% raw %}${{ matrix.python.version }}{% endraw %}
 
       - name: Setup C++
-        uses: actions-ext/cpp/setup@c2b1e90366b3a1c628a1df0748135f5e345ab26f
+        uses: actions-ext/cpp/setup@22ebafc6f57971978e964f9977333ac98a7c49d9
 
       {% if add_vcpkg -%}
       - name: Setup vcpkg cache
-        uses: actions-ext/cpp/setup-vcpkg-cache@c2b1e90366b3a1c628a1df0748135f5e345ab26f
+        uses: actions-ext/cpp/setup-vcpkg-cache@22ebafc6f57971978e964f9977333ac98a7c49d9
 
       {% endif -%}
       - name: Install dependencies
@@ -176,13 +176,13 @@ jobs:
         if: matrix.platform.name == 'windows-latest'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-wheel@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-sdist@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.platform.name == 'ubuntu-latest'

--- a/python/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/cpp/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/cppjswasm/.github/workflows/build.yaml.jinja
+++ b/python/cppjswasm/.github/workflows/build.yaml.jinja
@@ -66,22 +66,22 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: {% raw %}${{ matrix.python }}{% endraw %}
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
         if: matrix.target == 'native'
 
       - name: Setup C++
-        uses: actions-ext/cpp/setup@c2b1e90366b3a1c628a1df0748135f5e345ab26f
+        uses: actions-ext/cpp/setup@22ebafc6f57971978e964f9977333ac98a7c49d9
 
       {% if add_vcpkg -%}
       - name: Setup vcpkg cache
-        uses: actions-ext/cpp/setup-vcpkg-cache@c2b1e90366b3a1c628a1df0748135f5e345ab26f
+        uses: actions-ext/cpp/setup-vcpkg-cache@22ebafc6f57971978e964f9977333ac98a7c49d9
 
       {% endif -%}
       - name: Setup Emscripten
@@ -172,13 +172,13 @@ jobs:
         if: matrix.name == 'windows-latest'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-wheel@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-sdist@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.name == 'ubuntu-latest'

--- a/python/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/cppjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/js/.github/workflows/build.yaml.jinja
+++ b/python/js/.github/workflows/build.yaml.jinja
@@ -34,12 +34,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: "{{ python_version_primary }}"
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
 
@@ -79,12 +79,12 @@ jobs:
         run: make dist
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-wheel@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-sdist@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
 

--- a/python/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/js/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/jupyter/.github/workflows/build.yaml.jinja
+++ b/python/jupyter/.github/workflows/build.yaml.jinja
@@ -34,12 +34,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: "{{ python_version_primary }}"
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
 
@@ -79,12 +79,12 @@ jobs:
         run: make dist
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-wheel@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-sdist@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
 

--- a/python/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/jupyter/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/pure/.github/workflows/build.yaml.jinja
+++ b/python/pure/.github/workflows/build.yaml.jinja
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: "{{ python_version_primary }}"
 
@@ -74,12 +74,12 @@ jobs:
         run: make dist
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-wheel@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-sdist@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
 

--- a/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/pure/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/rust/.github/workflows/build.yaml.jinja
+++ b/python/rust/.github/workflows/build.yaml.jinja
@@ -66,12 +66,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: {% raw %}${{ matrix.python }}{% endraw %}
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@3de300f3071e758a1dd8545b884288a35e5d7f81
+        uses: actions-ext/rust/setup@0f0b7c9ab3cdb6e9a1f79e2147974d6762ddafea
 
       - name: Install dependencies
         run: make develop
@@ -156,13 +156,13 @@ jobs:
         if: matrix.target == 'native' && runner.os != 'Linux'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-wheel@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-sdist@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.name == 'ubuntu-latest'

--- a/python/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/rust/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/python/rustjswasm/.github/workflows/build.yaml.jinja
+++ b/python/rustjswasm/.github/workflows/build.yaml.jinja
@@ -66,15 +66,15 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           version: {% raw %}${{ matrix.python }}{% endraw %}
 
       - name: Setup Rust
-        uses: actions-ext/rust/setup@3de300f3071e758a1dd8545b884288a35e5d7f81
+        uses: actions-ext/rust/setup@0f0b7c9ab3cdb6e9a1f79e2147974d6762ddafea
 
       - name: Setup Node.js
-        uses: actions-ext/node/setup@b0536d87c5e92c924bc8667f566f620758280825
+        uses: actions-ext/node/setup@34d0fdbdca883e4d0a2da0bcd0fa460fd40b80e7
         with:
           version: 22.x
         if: matrix.target == 'native'
@@ -162,13 +162,13 @@ jobs:
         if: matrix.target == 'native' && runner.os != 'Linux'
 
       - name: Test wheel
-        uses: actions-ext/python/test-wheel@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-wheel@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.target == 'native' && runner.os == 'Linux'
 
       - name: Test source distribution
-        uses: actions-ext/python/test-sdist@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/test-sdist@ec67f82b3bd863948308a41ecb9e70547cbb19c7
         with:
           module: {{module}}
         if: matrix.name == 'ubuntu-latest'

--- a/python/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
+++ b/python/rustjswasm/.github/workflows/{% if add_docs %}docs.yaml{% endif %}.jinja
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions-ext/python/setup@a3f3953ef26a519ab7b6a56b94d06fa1b31ab3f3
+        uses: actions-ext/python/setup@ec67f82b3bd863948308a41ecb9e70547cbb19c7
 
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8


### PR DESCRIPTION
Follow-up to #182, which merged just before this commit landed on the branch.

The seven Dependabot PRs opened against the `actions-ext` repos all
auto-merged while #182 was open, moving every action repo's `main`. The pins
merged in #182 were already one round behind by the time they landed:

| action repo | merged in #182 | current main |
| --- | --- | --- |
| python | `a3f3953` | `ec67f82` |
| node | `b0536d8` | `34d0fdb` |
| rust | `3de300f` | `0f0b7c9` |
| cpp | `c2b1e90` | `22ebafc` |

Generated with `make update-action-pins` from #184.