### PR TITLE
Update JavaScript and Rust dependencies

### DIFF
--- a/javascript/site-react/package.json.jinja
+++ b/javascript/site-react/package.json.jinja
@@ -36,7 +36,7 @@
     "jsdom": "^30.0.1",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.81.0",
-    "typescript": "^7.0.2",
+    "typescript": "^5.9.3",
     "vite": "^8.2.2",
     "vitest": "^4.1.11"
   }

--- a/javascript/site-react/package.json.jinja
+++ b/javascript/site-react/package.json.jinja
@@ -25,19 +25,19 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.12.1",
-    "@playwright/test": "^1.60.0",
+    "@axe-core/playwright": "^4.13.0",
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "16.3.2",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
-    "@vitejs/plugin-react": "^6.1.0",
+    "@vitejs/plugin-react": "^6.1.1",
     "jsdom": "^30.0.1",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
-    "typescript": "^5.9.3",
-    "vite": "^8.1.5",
-    "vitest": "^4.1.8"
+    "oxlint": "^1.81.0",
+    "typescript": "^7.0.2",
+    "vite": "^8.2.2",
+    "vitest": "^4.1.11"
   }
 }

--- a/javascript/site-sveltekit/package.json.jinja
+++ b/javascript/site-sveltekit/package.json.jinja
@@ -32,7 +32,7 @@
     "svelte": "^5.57.0",
     "svelte-check": "^4.7.6",
     "tailwindcss": "^4.3.3",
-    "typescript": "^7.0.2",
+    "typescript": "^5.9.3",
     "vite": "^8.2.2"
   }
 }

--- a/javascript/site-sveltekit/package.json.jinja
+++ b/javascript/site-sveltekit/package.json.jinja
@@ -20,19 +20,19 @@
     "test:e2e:update": "playwright test --update-snapshots"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.12.1",
-    "@playwright/test": "^1.60.0",
+    "@axe-core/playwright": "^4.13.0",
+    "@playwright/test": "^1.62.1",
     "@sveltejs/adapter-{{ site_adapter }}": "{{ '^3.0.10' if site_adapter == 'static' else '^5.0.0' }}",
-    "@sveltejs/kit": "^2.70.1",
-    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@sveltejs/kit": "^2.70.3",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^24.0.0",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
-    "svelte": "^5.56.0",
-    "svelte-check": "^4.3.0",
+    "oxlint": "^1.81.0",
+    "svelte": "^5.57.0",
+    "svelte-check": "^4.7.6",
     "tailwindcss": "^4.3.3",
-    "typescript": "^5.9.3",
-    "vite": "^8.1.5"
+    "typescript": "^7.0.2",
+    "vite": "^8.2.2"
   }
 }

--- a/javascript/site-webawesome/package.json.jinja
+++ b/javascript/site-webawesome/package.json.jinja
@@ -28,7 +28,7 @@
     "@types/node": "^24.0.0",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.81.0",
-    "typescript": "^7.0.2",
+    "typescript": "^5.9.3",
     "vite": "^8.2.2"
   }
 }

--- a/javascript/site-webawesome/package.json.jinja
+++ b/javascript/site-webawesome/package.json.jinja
@@ -20,15 +20,15 @@
     "test:e2e:update": "playwright test --update-snapshots"
   },
   "dependencies": {
-    "@awesome.me/webawesome": "^3.11.0"
+    "@awesome.me/webawesome": "^3.12.0"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.12.1",
-    "@playwright/test": "^1.60.0",
+    "@axe-core/playwright": "^4.13.0",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^24.0.0",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
-    "typescript": "^5.9.3",
-    "vite": "^8.1.5"
+    "oxlint": "^1.81.0",
+    "typescript": "^7.0.2",
+    "vite": "^8.2.2"
   }
 }

--- a/javascript/uitk-svelte/package.json.jinja
+++ b/javascript/uitk-svelte/package.json.jinja
@@ -42,24 +42,24 @@
     "test:e2e:update": "playwright test --update-snapshots"
   },
   "peerDependencies": {
-    "svelte": "^5.0.0"
+    "svelte": "^5.57.0"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.12.1",
-    "@playwright/test": "^1.60.0",
+    "@axe-core/playwright": "^4.13.0",
+    "@playwright/test": "^1.62.1",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.70.1",
-    "@sveltejs/package": "^2.5.5",
-    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@sveltejs/kit": "^2.70.3",
+    "@sveltejs/package": "^2.5.8",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@types/node": "^24.0.0",
-    "jsdom": "^29.0.0",
+    "jsdom": "^30.0.1",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
-    "publint": "^0.3.21",
-    "svelte": "^5.56.0",
-    "svelte-check": "^4.3.0",
-    "typescript": "^5.9.3",
-    "vite": "^8.1.5",
-    "vitest": "^4.1.8"
+    "oxlint": "^1.81.0",
+    "publint": "^0.3.24",
+    "svelte": "^5.57.0",
+    "svelte-check": "^4.7.6",
+    "typescript": "^7.0.2",
+    "vite": "^8.2.2",
+    "vitest": "^4.1.11"
   }
 }

--- a/javascript/uitk-svelte/package.json.jinja
+++ b/javascript/uitk-svelte/package.json.jinja
@@ -58,7 +58,7 @@
     "publint": "^0.3.24",
     "svelte": "^5.57.0",
     "svelte-check": "^4.7.6",
-    "typescript": "^7.0.2",
+    "typescript": "^5.9.3",
     "vite": "^8.2.2",
     "vitest": "^4.1.11"
   }

--- a/javascript/uitk-webawesome/package.json.jinja
+++ b/javascript/uitk-webawesome/package.json.jinja
@@ -53,7 +53,7 @@
     "oxfmt": "^0.63.0",
     "oxlint": "^1.81.0",
     "publint": "^0.3.24",
-    "typescript": "^7.0.2",
+    "typescript": "^5.9.3",
     "vite": "^8.2.2",
     "vitest": "^4.1.11"
   }

--- a/javascript/uitk-webawesome/package.json.jinja
+++ b/javascript/uitk-webawesome/package.json.jinja
@@ -40,21 +40,21 @@
     "test:e2e:update": "playwright test --update-snapshots"
   },
   "peerDependencies": {
-    "@awesome.me/webawesome": "^3.11.0",
+    "@awesome.me/webawesome": "^3.12.0",
     "lit": "^3.3.3"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.12.1",
-    "@playwright/test": "^1.60.0",
-    "@awesome.me/webawesome": "^3.11.0",
+    "@axe-core/playwright": "^4.13.0",
+    "@playwright/test": "^1.62.1",
+    "@awesome.me/webawesome": "^3.12.0",
     "lit": "^3.3.3",
     "@types/node": "^24.0.0",
-    "jsdom": "^29.0.0",
+    "jsdom": "^30.0.1",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
-    "publint": "^0.3.21",
-    "typescript": "^5.9.3",
-    "vite": "^8.1.5",
-    "vitest": "^4.1.8"
+    "oxlint": "^1.81.0",
+    "publint": "^0.3.24",
+    "typescript": "^7.0.2",
+    "vite": "^8.2.2",
+    "vitest": "^4.1.11"
   }
 }

--- a/python/cppjswasm/js/package.json.jinja
+++ b/python/cppjswasm/js/package.json.jinja
@@ -49,15 +49,15 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "cpy": "^13.2.2",
-    "esbuild": "^0.28.1",
+    "esbuild": "^0.28.2",
     "lightningcss": "^1.33.0",
     "http-server": "^14.1.1",
-    "nodemon": "^3.1.10",
+    "nodemon": "^3.1.14",
     "npm-run-all": "^4.1.5",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
+    "oxlint": "^1.81.0",
     "typescript": "^7.0.2"
   }
 }

--- a/python/js/js/package.json.jinja
+++ b/python/js/js/package.json.jinja
@@ -42,15 +42,15 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "cpy": "^13.2.2",
-    "esbuild": "^0.28.1",
+    "esbuild": "^0.28.2",
     "lightningcss": "^1.33.0",
     "http-server": "^14.1.1",
-    "nodemon": "^3.1.10",
+    "nodemon": "^3.1.14",
     "npm-run-all": "^4.1.5",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
+    "oxlint": "^1.81.0",
     "typescript": "^7.0.2"
   }
 }

--- a/python/jupyter/js/package.json.jinja
+++ b/python/jupyter/js/package.json.jinja
@@ -43,27 +43,27 @@
     "test": "jest --coverage --collectCoverageFrom=src/*.{js}"
   },
   "dependencies": {
-    "@jupyterlab/application": "^4.5.7",
-    "@jupyterlab/apputils": "^4.6.7",
-    "@jupyterlab/notebook": "^4.5.7",
-    "@jupyterlab/services": "^7.5.10",
-    "@lumino/disposable": "^2.1.5"
+    "@jupyterlab/application": "^4.6.3",
+    "@jupyterlab/apputils": "^4.7.3",
+    "@jupyterlab/notebook": "^4.6.3",
+    "@jupyterlab/services": "^7.6.3",
+    "@lumino/disposable": "^2.1.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.3",
     "@jupyterlab/builder": "^4.5.10",
-    "babel-jest": "^30.4.1",
+    "babel-jest": "^30.5.1",
     "cpy-cli": "^6.0.0",
     "isomorphic-fetch": "^3.0.0",
-    "jest": "^30.4.2",
-    "jest-environment-jsdom": "^30.4.1",
+    "jest": "^30.5.1",
+    "jest-environment-jsdom": "^30.5.1",
     "jest-junit": "^17.0.0",
     "jest-transform-css": "^6.0.3",
     "mkdirp": "^3.0.1",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
+    "oxlint": "^1.81.0",
     "rimraf": "^6.1.3"
   }
 }

--- a/python/rust/Cargo.toml.jinja
+++ b/python/rust/Cargo.toml.jinja
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 {{ module }} = { path = "./rust", version = "*" }
-pyo3 = { version = "0.29.0", features = ["abi3", "extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.29.2", features = ["abi3", "extension-module", "multiple-pymethods"] }
 
 [profile.release]
 panic = 'abort'

--- a/python/rustjswasm/Cargo.toml.jinja
+++ b/python/rustjswasm/Cargo.toml.jinja
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 {{ module }} = { path = "./rust", version = "*" }
-pyo3 = { version = "0.29.0", features = ["abi3", "extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.29.2", features = ["abi3", "extension-module", "multiple-pymethods"] }
 
 [profile.release]
 panic = 'abort'

--- a/python/rustjswasm/js/package.json.jinja
+++ b/python/rustjswasm/js/package.json.jinja
@@ -52,15 +52,15 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "cpy": "^13.2.2",
-    "esbuild": "^0.28.1",
+    "esbuild": "^0.28.2",
     "lightningcss": "^1.33.0",
     "http-server": "^14.1.1",
     "nodemon": "^3.1.14",
     "npm-run-all": "^4.1.5",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.78.0",
+    "oxlint": "^1.81.0",
     "typescript": "^7.0.2"
   }
 }


### PR DESCRIPTION
Nothing watches the templates' own manifests — the `dependabot.yaml` files ship
to generated projects, and no config in this repo scans `package.json.jinja` or
`Cargo.toml.jinja`. These specs had drifted accordingly.

Raises 25 dependency floors to the current release. Most are cosmetic, since
the caret ranges already resolved to these versions; the declared floors were
just stale.

Settles the five specs that disagreed between templates:

| package | was | now |
| --- | --- | --- |
| `jsdom` | `^29.0.0` / `^30.0.1` | `^30.0.1` |
| `@playwright/test` | `^1.60.0` / `^1.62.0` | `^1.62.1` |
| `svelte` | `^5.0.0` / `^5.56.0` | `^5.57.0` |
| `nodemon` | `^3.1.10` / `^3.1.14` | `^3.1.14` |

The jsdom row is a real upgrade for the JavaScript templates, not a floor bump.

`typescript` is deliberately left split: `^5.9.3` in the JavaScript templates,
`^7.0.2` in the Python templates' js projects. Unifying it fails two ways —
svelte-check 4.x refuses TypeScript 7 unless both 6 and 7 are installed behind
an npm alias, and TypeScript 7 raises TS2882 on the side-effect CSS imports the
Web Awesome templates use.

Rust: `pyo3` `0.29.0` to `0.29.2`. `serde` and `wasm-bindgen` were current.

Deliberately not included, as cross-major upgrades wanting their own review:
babel 7 to 8, `@types/node` 24 to 26, `cpy-cli` 6 to 7, and `oxfmt` 0.63 to
0.66. The `oxfmt` bump in particular can change formatting results. The exact
pin on `@testing-library/react` is left as-is.
