### PR TITLE
Replace the generated design vocabulary in the JS templates

### DIFF
--- a/javascript/site-react/src/App.tsx.jinja
+++ b/javascript/site-react/src/App.tsx.jinja
@@ -1,7 +1,6 @@
 export default function App() {
   return (
     <main>
-      <p className="eyebrow">{{ brand_name }}</p>
       <h1>{{ brand_name }}</h1>
       <p>{{ project_description }}</p>
       <a className="button" href="#develop">

--- a/javascript/site-react/src/styles.css.jinja
+++ b/javascript/site-react/src/styles.css.jinja
@@ -1,7 +1,14 @@
 :root {
-  color: #171717;
-  background: #ffffff;
+  --{{ css_prefix }}-bg: #ffffff;
+  --{{ css_prefix }}-fg: #171717;
+  --{{ css_prefix }}-fg-muted: #5c5c5c;
+  --{{ css_prefix }}-border: #e0e0e0;
+  --{{ css_prefix }}-focus: #1a56c4;
+
+  color: var(--{{ css_prefix }}-fg);
+  background: var(--{{ css_prefix }}-bg);
   font-family: system-ui, sans-serif;
+  color-scheme: light;
 }
 
 body {
@@ -11,34 +18,32 @@ body {
 main {
   width: min(calc(100% - 3rem), 64rem);
   margin: 0 auto;
-  padding: 6rem 0;
-}
-
-.eyebrow {
-  font-size: 0.75rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  padding: 3rem 0 6rem;
 }
 
 h1 {
-  margin: 2rem 0 1rem;
-  font-size: clamp(3rem, 10vw, 8rem);
-  line-height: 0.9;
-  letter-spacing: -0.06em;
+  margin: 0 0 1rem;
+  font-size: 1.75rem;
+  font-weight: 600;
 }
 
-main > p:not(.eyebrow) {
-  max-width: 42rem;
+main > p {
+  max-width: 60ch;
   margin-bottom: 2rem;
-  font-size: 1.25rem;
+  color: var(--{{ css_prefix }}-fg-muted);
   line-height: 1.6;
 }
 
 .button {
   display: inline-block;
-  padding: 0.75rem 1rem;
-  color: #ffffff;
-  background: #171717;
-  border-radius: 0.35rem;
+  padding: 0.6rem 1rem;
+  color: var(--{{ css_prefix }}-bg);
+  background: var(--{{ css_prefix }}-fg);
   text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--{{ css_prefix }}-focus);
+  outline-offset: 4px;
 }

--- a/javascript/site-sveltekit/src/app.css.jinja
+++ b/javascript/site-sveltekit/src/app.css.jinja
@@ -1,37 +1,51 @@
 @import 'tailwindcss';
 
+/* Neutral placeholders. Replace the values with the brand's own; the names are
+ * the contract the rest of the site depends on. */
+
 :root {
-  --paper: #ffffff;
-  --ink: #171717;
-  --muted: #5c5c5c;
-  --line: #e4e4e4;
+  --{{ css_prefix }}-bg: #ffffff;
+  --{{ css_prefix }}-bg-raised: #f6f6f6;
+  --{{ css_prefix }}-fg: #171717;
+  --{{ css_prefix }}-fg-muted: #5c5c5c;
+  --{{ css_prefix }}-border: #e0e0e0;
+  --{{ css_prefix }}-focus: #1a56c4;
 
   color-scheme: light;
 }
 
 :root[data-theme='dark'] {
-  --paper: #0b0b0b;
-  --ink: #f2f2f2;
-  --muted: #a1a1a1;
-  --line: #262626;
+  --{{ css_prefix }}-bg: #121212;
+  --{{ css_prefix }}-bg-raised: #1c1c1c;
+  --{{ css_prefix }}-fg: #ededed;
+  --{{ css_prefix }}-fg-muted: #a6a6a6;
+  --{{ css_prefix }}-border: #333333;
+  --{{ css_prefix }}-focus: #8ab4ff;
 
   color-scheme: dark;
 }
 
 @theme inline {
-  --color-paper: var(--paper);
-  --color-ink: var(--ink);
-  --color-muted: var(--muted);
-  --color-line: var(--line);
+  --color-bg: var(--{{ css_prefix }}-bg);
+  --color-bg-raised: var(--{{ css_prefix }}-bg-raised);
+  --color-fg: var(--{{ css_prefix }}-fg);
+  --color-fg-muted: var(--{{ css_prefix }}-fg-muted);
+  --color-border: var(--{{ css_prefix }}-border);
 }
 
 body {
   margin: 0;
-  color: var(--ink);
-  background: var(--paper);
+  color: var(--{{ css_prefix }}-fg);
+  background: var(--{{ css_prefix }}-bg);
   font-family: system-ui, sans-serif;
 }
 
 a {
   color: inherit;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--{{ css_prefix }}-focus);
+  outline-offset: 4px;
 }

--- a/javascript/site-webawesome/index.html.jinja
+++ b/javascript/site-webawesome/index.html.jinja
@@ -15,8 +15,7 @@
   </head>
   <body>
     <main>
-      <p class="eyebrow">{{ brand_name }}</p>
-      <h1>{{ project_name }}</h1>
+      <h1>{{ brand_name }}</h1>
       <p>{{ project_description }}</p>
       <wa-button variant="brand">Get started</wa-button>
     </main>

--- a/javascript/site-webawesome/src/styles.css.jinja
+++ b/javascript/site-webawesome/src/styles.css.jinja
@@ -1,7 +1,14 @@
 :root {
-  color: #171717;
-  background: #ffffff;
+  --{{ css_prefix }}-bg: #ffffff;
+  --{{ css_prefix }}-fg: #171717;
+  --{{ css_prefix }}-fg-muted: #5c5c5c;
+  --{{ css_prefix }}-border: #e0e0e0;
+  --{{ css_prefix }}-focus: #1a56c4;
+
+  color: var(--{{ css_prefix }}-fg);
+  background: var(--{{ css_prefix }}-bg);
   font-family: system-ui, sans-serif;
+  color-scheme: light;
 }
 
 body {
@@ -11,25 +18,24 @@ body {
 main {
   width: min(calc(100% - 3rem), 64rem);
   margin: 0 auto;
-  padding: 6rem 0;
-}
-
-.eyebrow {
-  font-size: 0.75rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  padding: 3rem 0 6rem;
 }
 
 h1 {
-  margin: 2rem 0 1rem;
-  font-size: clamp(3rem, 10vw, 8rem);
-  line-height: 0.9;
-  letter-spacing: -0.06em;
+  margin: 0 0 1rem;
+  font-size: 1.75rem;
+  font-weight: 600;
 }
 
-main > p:not(.eyebrow) {
-  max-width: 42rem;
+main > p {
+  max-width: 60ch;
   margin-bottom: 2rem;
-  font-size: 1.25rem;
+  color: var(--{{ css_prefix }}-fg-muted);
   line-height: 1.6;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--{{ css_prefix }}-focus);
+  outline-offset: 4px;
 }

--- a/javascript/uitk-svelte/BRAND.md.jinja
+++ b/javascript/uitk-svelte/BRAND.md.jinja
@@ -1,24 +1,42 @@
 # {{ brand_name }} Brand Guide
 
-Canonical source for the {{ brand_name }} identity. Replace each placeholder before publishing the first consumer.
+Canonical source for the {{ brand_name }} identity. Every section below is a
+placeholder — fill it in before publishing the first consumer.
 
 ## Identity
 
-Describe what {{ brand_name }} is, who it serves, and what it must not be confused with.
+Describe what {{ brand_name }} is, who it serves, and what it must not be
+confused with.
 
 ## Mark
 
-Document primary mark, clear space, minimum size, and approved variants.
+Document the primary mark, clear space, minimum size, and approved variants.
 
 ## Color
 
-| Role   | Light     | Dark      | Usage              |
-| ------ | --------- | --------- | ------------------ |
-| Paper  | `#f5f5f0` | `#151515` | Page surfaces      |
-| Ink    | `#151515` | `#f5f5f0` | Primary content    |
-| Muted  | `#666660` | `#aaa9a0` | Supporting content |
-| Line   | `#d0d0c8` | `#3a3a36` | Borders and rules  |
-| Accent | `#6cff8f` | `#6cff8f` | Focus and emphasis |
+The shipped tokens are neutral greys plus a functional focus color. They exist
+so the toolkit renders legibly out of the box, not because they are the brand.
+Replace the values in `tokens.css`, then record them here.
+
+| Token       | Light | Dark | Usage             |
+| ----------- | ----- | ---- | ----------------- |
+| `bg`        |       |      | Page background   |
+| `bg-raised` |       |      | Raised surfaces   |
+| `fg`        |       |      | Primary text      |
+| `fg-muted`  |       |      | Supporting text   |
+| `border`    |       |      | Borders and rules |
+| `focus`     |       |      | Focus rings       |
+
+Two rules worth keeping whatever the palette becomes:
+
+- Name tokens for the role a color plays, not a material it imitates. Roles
+  survive a redesign; metaphors have to be renamed or quietly start lying.
+- Give every color a job. A single decorative accent applied wherever a page
+  looks flat is how unrelated products end up looking identical.
+
+Verify each foreground against the surfaces behind it — WCAG AA is 4.5:1 for
+normal text, and a focus ring needs 3:1. Assert it in a test so the palette
+cannot drift.
 
 ## Typography
 

--- a/javascript/uitk-svelte/src/lib/components/BrandMark.svelte.jinja
+++ b/javascript/uitk-svelte/src/lib/components/BrandMark.svelte.jinja
@@ -24,8 +24,7 @@
     height: 2rem;
     place-items: center;
     border-radius: 50%;
-    color: var(--{{ css_prefix }}-color-paper);
-    background: var(--{{ css_prefix }}-color-ink);
-    box-shadow: 3px 3px 0 var(--{{ css_prefix }}-color-accent);
+    color: var(--{{ css_prefix }}-bg);
+    background: var(--{{ css_prefix }}-fg);
   }
 </style>

--- a/javascript/uitk-svelte/src/lib/components/ThemeToggle.svelte.jinja
+++ b/javascript/uitk-svelte/src/lib/components/ThemeToggle.svelte.jinja
@@ -20,9 +20,9 @@
 <style>
   button {
     padding: 0.5rem 0.75rem;
-    border: 1px solid var(--{{ css_prefix }}-color-line);
-    color: var(--{{ css_prefix }}-color-ink);
-    background: var(--{{ css_prefix }}-color-paper);
+    border: 1px solid var(--{{ css_prefix }}-border);
+    color: var(--{{ css_prefix }}-fg);
+    background: var(--{{ css_prefix }}-bg);
     cursor: pointer;
   }
 </style>

--- a/javascript/uitk-svelte/src/lib/styles/tokens.css.jinja
+++ b/javascript/uitk-svelte/src/lib/styles/tokens.css.jinja
@@ -1,26 +1,49 @@
+/* Design tokens for {{ brand_name }}.
+ *
+ * These are deliberately neutral placeholders, not a finished palette. Replace
+ * the values with the brand's own before shipping; the names are the contract
+ * consumers depend on, so prefer changing values over renaming.
+ *
+ * Names describe the role a color plays, not a material it imitates.
+ */
+
 :root {
-  --{{ css_prefix }}-color-paper: #f5f5f0;
-  --{{ css_prefix }}-color-ink: #151515;
-  --{{ css_prefix }}-color-muted: #666660;
-  --{{ css_prefix }}-color-line: #d0d0c8;
-  --{{ css_prefix }}-color-accent: #6cff8f;
+  /* surfaces */
+  --{{ css_prefix }}-bg: #ffffff;
+  --{{ css_prefix }}-bg-raised: #f6f6f6;
+
+  /* text */
+  --{{ css_prefix }}-fg: #171717;
+  --{{ css_prefix }}-fg-muted: #5c5c5c;
+
+  /* structure */
+  --{{ css_prefix }}-border: #e0e0e0;
+
+  /* Focus is a functional requirement, not decoration. It needs at least 3:1
+   * against both surfaces above; check it whenever the palette changes. */
+  --{{ css_prefix }}-focus: #1a56c4;
+
   --{{ css_prefix }}-font-sans: ui-sans-serif, system-ui, sans-serif;
   --{{ css_prefix }}-font-mono: ui-monospace, monospace;
+
   color-scheme: light;
 }
 
 :root[data-theme='dark'] {
-  --{{ css_prefix }}-color-paper: #151515;
-  --{{ css_prefix }}-color-ink: #f5f5f0;
-  --{{ css_prefix }}-color-muted: #aaa9a0;
-  --{{ css_prefix }}-color-line: #3a3a36;
+  --{{ css_prefix }}-bg: #121212;
+  --{{ css_prefix }}-bg-raised: #1c1c1c;
+  --{{ css_prefix }}-fg: #ededed;
+  --{{ css_prefix }}-fg-muted: #a6a6a6;
+  --{{ css_prefix }}-border: #333333;
+  --{{ css_prefix }}-focus: #8ab4ff;
+
   color-scheme: dark;
 }
 
 :root {
-  color: var(--{{ css_prefix }}-color-ink);
+  color: var(--{{ css_prefix }}-fg);
   font-family: var(--{{ css_prefix }}-font-sans);
-  background: var(--{{ css_prefix }}-color-paper);
+  background: var(--{{ css_prefix }}-bg);
 }
 
 body {
@@ -29,6 +52,6 @@ body {
 
 button:focus-visible,
 a:focus-visible {
-  outline: 2px solid var(--{{ css_prefix }}-color-accent);
+  outline: 2px solid var(--{{ css_prefix }}-focus);
   outline-offset: 4px;
 }

--- a/javascript/uitk-svelte/src/routes/+page.svelte.jinja
+++ b/javascript/uitk-svelte/src/routes/+page.svelte.jinja
@@ -5,32 +5,68 @@
 <svelte:head><title>{{ brand_name }} brand kit</title></svelte:head>
 
 <main>
-  <p class="eyebrow">Brand toolkit</p>
-  <BrandMark />
+  <header>
+    <BrandMark />
+    <ThemeToggle />
+  </header>
+
   <h1>{{ brand_name }}</h1>
-  <p>{{ project_description }}</p>
-  <ThemeToggle />
+  <p class="lede">{{ project_description }}</p>
+
+  <section aria-labelledby="tokens">
+    <h2 id="tokens">Tokens</h2>
+    <p>
+      Colors, type, and spacing live in <code>src/lib/styles/tokens.css</code>. The values there are neutral
+      placeholders — replace them with the brand's own.
+    </p>
+  </section>
 </main>
 
 <style>
   main {
-    width: min(calc(100% - 3rem), 72rem);
+    width: min(calc(100% - 3rem), 64rem);
     margin: 0 auto;
-    padding: 6rem 0;
+    padding: 3rem 0 6rem;
   }
 
-  .eyebrow {
-    color: var(--{{ css_prefix }}-color-muted);
-    font-family: var(--{{ css_prefix }}-font-mono);
-    font-size: 0.75rem;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--{{ css_prefix }}-border);
   }
 
   h1 {
-    margin: 4rem 0 1rem;
-    font-size: clamp(4rem, 12vw, 10rem);
-    line-height: 0.85;
-    letter-spacing: -0.06em;
+    margin: 2.5rem 0 0.5rem;
+    font-size: 1.75rem;
+    font-weight: 600;
+  }
+
+  h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .lede {
+    margin: 0;
+    max-width: 60ch;
+    color: var(--{{ css_prefix }}-fg-muted);
+  }
+
+  section {
+    margin-top: 2.5rem;
+    max-width: 60ch;
+  }
+
+  section p {
+    margin: 0;
+    color: var(--{{ css_prefix }}-fg-muted);
+  }
+
+  code {
+    font-family: var(--{{ css_prefix }}-font-mono);
   }
 </style>

--- a/javascript/uitk-webawesome/BRAND.md.jinja
+++ b/javascript/uitk-webawesome/BRAND.md.jinja
@@ -1,24 +1,42 @@
 # {{ brand_name }} Brand Guide
 
-Canonical source for the {{ brand_name }} identity. Replace each placeholder before publishing the first consumer.
+Canonical source for the {{ brand_name }} identity. Every section below is a
+placeholder — fill it in before publishing the first consumer.
 
 ## Identity
 
-Describe what {{ brand_name }} is, who it serves, and what it must not be confused with.
+Describe what {{ brand_name }} is, who it serves, and what it must not be
+confused with.
 
 ## Mark
 
-Document primary mark, clear space, minimum size, and approved variants.
+Document the primary mark, clear space, minimum size, and approved variants.
 
 ## Color
 
-| Role   | Light     | Dark      | Usage              |
-| ------ | --------- | --------- | ------------------ |
-| Paper  | `#f5f5f0` | `#151515` | Page surfaces      |
-| Ink    | `#151515` | `#f5f5f0` | Primary content    |
-| Muted  | `#666660` | `#aaa9a0` | Supporting content |
-| Line   | `#d0d0c8` | `#3a3a36` | Borders and rules  |
-| Accent | `#6cff8f` | `#6cff8f` | Focus and emphasis |
+The shipped tokens are neutral greys plus a functional focus color. They exist
+so the toolkit renders legibly out of the box, not because they are the brand.
+Replace the values in `tokens.css`, then record them here.
+
+| Token       | Light | Dark | Usage             |
+| ----------- | ----- | ---- | ----------------- |
+| `bg`        |       |      | Page background   |
+| `bg-raised` |       |      | Raised surfaces   |
+| `fg`        |       |      | Primary text      |
+| `fg-muted`  |       |      | Supporting text   |
+| `border`    |       |      | Borders and rules |
+| `focus`     |       |      | Focus rings       |
+
+Two rules worth keeping whatever the palette becomes:
+
+- Name tokens for the role a color plays, not a material it imitates. Roles
+  survive a redesign; metaphors have to be renamed or quietly start lying.
+- Give every color a job. A single decorative accent applied wherever a page
+  looks flat is how unrelated products end up looking identical.
+
+Verify each foreground against the surfaces behind it — WCAG AA is 4.5:1 for
+normal text, and a focus ring needs 3:1. Assert it in a test so the palette
+cannot drift.
 
 ## Typography
 

--- a/javascript/uitk-webawesome/index.html.jinja
+++ b/javascript/uitk-webawesome/index.html.jinja
@@ -19,8 +19,8 @@
   </head>
   <body>
     <main>
-      <p class="eyebrow">Brand toolkit</p>
       <{{ element_prefix }}-brand-mark></{{ element_prefix }}-brand-mark>
+      <h1>{{ brand_name }}</h1>
       <p>{{ project_description }}</p>
       <{{ element_prefix }}-theme-toggle data-testid="theme-toggle"></{{ element_prefix }}-theme-toggle>
     </main>

--- a/javascript/uitk-webawesome/src/lit/components/brand-mark.ts.jinja
+++ b/javascript/uitk-webawesome/src/lit/components/brand-mark.ts.jinja
@@ -19,9 +19,9 @@ export class BrandMark extends LitElement {
       height: 2rem;
       place-items: center;
       border-radius: 50%;
-      color: var(--{{ css_prefix }}-color-paper);
-      background: var(--{{ css_prefix }}-color-ink);
-      box-shadow: 3px 3px 0 var(--{{ css_prefix }}-color-accent);
+      color: var(--{{ css_prefix }}-bg);
+      background: var(--{{ css_prefix }}-fg);
+      box-shadow: 3px 3px 0 var(--{{ css_prefix }}-focus);
     }
   `;
 

--- a/javascript/uitk-webawesome/src/lit/components/theme-toggle.ts.jinja
+++ b/javascript/uitk-webawesome/src/lit/components/theme-toggle.ts.jinja
@@ -9,9 +9,9 @@ export class ThemeToggle extends LitElement {
 
   static styles = css`
     wa-button::part(base) {
-      border-color: var(--{{ css_prefix }}-color-line);
-      color: var(--{{ css_prefix }}-color-ink);
-      background: var(--{{ css_prefix }}-color-paper);
+      border-color: var(--{{ css_prefix }}-border);
+      color: var(--{{ css_prefix }}-fg);
+      background: var(--{{ css_prefix }}-bg);
     }
   `;
 

--- a/javascript/uitk-webawesome/src/lit/styles/tokens.css.jinja
+++ b/javascript/uitk-webawesome/src/lit/styles/tokens.css.jinja
@@ -1,29 +1,57 @@
+/* Design tokens for {{ brand_name }}.
+ *
+ * These are deliberately neutral placeholders, not a finished palette. Replace
+ * the values with the brand's own before shipping; the names are the contract
+ * consumers depend on, so prefer changing values over renaming.
+ *
+ * Names describe the role a color plays, not a material it imitates.
+ */
+
 :root {
-  --{{ css_prefix }}-color-paper: #f5f5f0;
-  --{{ css_prefix }}-color-ink: #151515;
-  --{{ css_prefix }}-color-muted: #666660;
-  --{{ css_prefix }}-color-line: #d0d0c8;
-  --{{ css_prefix }}-color-accent: #6cff8f;
+  /* surfaces */
+  --{{ css_prefix }}-bg: #ffffff;
+  --{{ css_prefix }}-bg-raised: #f6f6f6;
+
+  /* text */
+  --{{ css_prefix }}-fg: #171717;
+  --{{ css_prefix }}-fg-muted: #5c5c5c;
+
+  /* structure */
+  --{{ css_prefix }}-border: #e0e0e0;
+
+  /* Focus is a functional requirement, not decoration. It needs at least 3:1
+   * against both surfaces above; check it whenever the palette changes. */
+  --{{ css_prefix }}-focus: #1a56c4;
+
   --{{ css_prefix }}-font-sans: ui-sans-serif, system-ui, sans-serif;
   --{{ css_prefix }}-font-mono: ui-monospace, monospace;
-  --wa-color-surface-default: var(--{{ css_prefix }}-color-paper);
-  --wa-color-text-normal: var(--{{ css_prefix }}-color-ink);
-  --wa-color-brand-fill-loud: var(--{{ css_prefix }}-color-accent);
+
+  /* Bridge into Web Awesome. Only surfaces, text, and borders are mapped:
+   * Web Awesome's brand color is the consumer's to choose, so it is left at
+   * the library default rather than pointed at a placeholder. */
+  --wa-color-surface-default: var(--{{ css_prefix }}-bg);
+  --wa-color-surface-raised: var(--{{ css_prefix }}-bg-raised);
+  --wa-color-text-normal: var(--{{ css_prefix }}-fg);
+  --wa-color-text-quiet: var(--{{ css_prefix }}-fg-muted);
+
   color-scheme: light;
 }
 
 :root[data-theme='dark'] {
-  --{{ css_prefix }}-color-paper: #151515;
-  --{{ css_prefix }}-color-ink: #f5f5f0;
-  --{{ css_prefix }}-color-muted: #aaa9a0;
-  --{{ css_prefix }}-color-line: #3a3a36;
+  --{{ css_prefix }}-bg: #121212;
+  --{{ css_prefix }}-bg-raised: #1c1c1c;
+  --{{ css_prefix }}-fg: #ededed;
+  --{{ css_prefix }}-fg-muted: #a6a6a6;
+  --{{ css_prefix }}-border: #333333;
+  --{{ css_prefix }}-focus: #8ab4ff;
+
   color-scheme: dark;
 }
 
 :root {
-  color: var(--{{ css_prefix }}-color-ink);
+  color: var(--{{ css_prefix }}-fg);
   font-family: var(--{{ css_prefix }}-font-sans);
-  background: var(--{{ css_prefix }}-color-paper);
+  background: var(--{{ css_prefix }}-bg);
 }
 
 body {
@@ -31,15 +59,13 @@ body {
 }
 
 main {
-  width: min(calc(100% - 3rem), 72rem);
+  width: min(calc(100% - 3rem), 64rem);
   margin: 0 auto;
-  padding: 6rem 0;
+  padding: 3rem 0 6rem;
 }
 
-.eyebrow {
-  color: var(--{{ css_prefix }}-color-muted);
-  font-family: var(--{{ css_prefix }}-font-mono);
-  font-size: 0.75rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--{{ css_prefix }}-focus);
+  outline-offset: 4px;
 }


### PR DESCRIPTION
Five JavaScript extensions shipped the same design system into every project generated from them. Two unrelated sites built from this template — `tim.paine.nyc` and a Hasan Piker clip archive — turned out to be recognisably the same design, down to a moon icon path differing by three tenths of a unit.

The common source is here.

## What every generated project was getting

| | |
| --- | --- |
| Tokens | `paper` / `ink` / `muted` / `line` / `accent` |
| Accent | `#6cff8f`, applied wherever a page looked flat |
| Eyebrow | `.eyebrow { font-size: .75rem; letter-spacing: .14em; text-transform: uppercase }` |
| Headline | `h1 { font-size: clamp(3rem, 10vw, 8rem); line-height: .85; letter-spacing: -.06em }` |

Affected: `uitk-svelte`, `uitk-webawesome`, `site-react`, `site-sveltekit`, `site-webawesome`.

## Changes

**Tokens are named for the role a color plays, not a material it imitates.**

```
paper → bg          ink   → fg
                    muted → fg-muted
line  → border      accent → (removed)
                    bg-raised, focus (new)
```

Roles survive a redesign; metaphors have to be renamed or quietly start lying. `paper`/`ink` also carry an aesthetic — they presume a print look before the consumer has chosen one.

**The decorative accent is gone.** `focus` replaces it and is the only non-neutral color left, because a focus ring is an accessibility requirement rather than a flourish. A single accent applied wherever a page looks flat is precisely how unrelated products end up looking identical.

**Defaults are plain greys, documented as placeholders.** They exist so a generated project renders legibly on first run, not because they are anyone's brand.

**The eyebrow and the oversized headline are removed** from both toolkit galleries and all three site templates.

**`BRAND.md` no longer ships a filled-in palette** that consumers keep by default. It is now a table to complete, plus the two rules worth keeping whatever the palette becomes.

## Verification

All five templates render, lint, type-check and build:

```
copier copy . <out> --data-file examples/<t>.yaml   # ✓ ×5
pnpm lint && pnpm check && pnpm build               # ✓ ×5
```

Contrast on the shipped defaults, computed against WCAG 2.1 relative luminance:

| Pair | Light | Dark | Needs |
| --- | --- | --- | --- |
| `fg` on `bg` | 17.93 | 16.00 | 4.5 |
| `fg` on `bg-raised` | 16.59 | 14.56 | 4.5 |
| `fg-muted` on `bg` | 6.69 | 7.70 | 4.5 |
| `fg-muted` on `bg-raised` | 6.19 | 7.00 | 4.5 |
| `focus` on `bg` | 6.62 | 8.97 | 3.0 |
| `focus` on `bg-raised` | 6.13 | 8.16 | 3.0 |

## Breaking change

This renames the public CSS custom-property contract. Existing generated projects will conflict on `copier update` and must map the old names to the new ones. Given the tokens are the thing being fixed, a rename is the point rather than a side effect.

`timkpaine/ui` has already moved off this vocabulary independently (timkpaine/ui#3) and will conflict on these files regardless.
